### PR TITLE
chore : chat도메인 db,entity,repository등 초기설정

### DIFF
--- a/meerket/build.gradle
+++ b/meerket/build.gradle
@@ -36,6 +36,7 @@ subprojects {
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-validation'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/meerket/meerket-application/build.gradle
+++ b/meerket/meerket-application/build.gradle
@@ -14,4 +14,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    // ObjectId 를 위한 mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }

--- a/meerket/meerket-domain/build.gradle
+++ b/meerket/meerket-domain/build.gradle
@@ -17,6 +17,10 @@ dependencies {
     implementation 'org.hibernate:hibernate-spatial:6.4.1.Final'
     implementation 'org.locationtech.jts:jts-core:1.19.0'
 
+    // 채팅에서 mongodb 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+
 
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/config/MongoConfig.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/config/MongoConfig.java
@@ -1,0 +1,37 @@
+package org.j1p5.domain.chat.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableMongoRepositories(
+        basePackages = "org.j1p5.domain.chat.repository")
+public class MongoConfig {
+
+    @Value("${spring.data.mongodb.uri}")
+    private String mongoUri;
+
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create(mongoUri);
+    }
+
+    @Bean
+    public MongoDatabaseFactory mongoDatabaseFactory(MongoClient mongoClient) {
+        return new SimpleMongoClientDatabaseFactory(mongoClient, "chatdb");
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate(MongoDatabaseFactory mongoDatabaseFactory) {
+        return new MongoTemplate(mongoDatabaseFactory);
+    }
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/entity/ChatMessageEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/entity/ChatMessageEntity.java
@@ -1,0 +1,41 @@
+package org.j1p5.domain.chat.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.bson.types.ObjectId;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@Document(collection = "messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageEntity {
+
+    @Id
+    private ObjectId id;
+    private ObjectId roomId;
+    private Long senderId;
+    private String content;
+    private LocalDateTime createdAt;
+
+
+    public static ChatMessageEntity create(ObjectId roomId, Long senderId, String content) {
+        return new ChatMessageEntity(
+                Objects.requireNonNull(roomId, "roomId는 필수입니다."),
+                Objects.requireNonNull(senderId, "senderId는 필수입니다."),
+                Objects.requireNonNull(content, "내용은 필수 입니다.")
+        );
+    }
+
+    private ChatMessageEntity(ObjectId roomId, Long senderId, String content) {
+        this.roomId = roomId;
+        this.senderId = senderId;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/entity/ChatRoomEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/entity/ChatRoomEntity.java
@@ -1,0 +1,55 @@
+package org.j1p5.domain.chat.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "chat_rooms")
+public class ChatRoomEntity {
+
+    @Id
+    private ObjectId id;
+    private Long sellerId;
+    private Long buyerId;
+    private Long productId;
+    private String productImage;
+    private String productTitle;
+    private int price;
+    private String lastMessage;
+    private LocalDateTime lastMessageAt;
+    private LocalDateTime createdAt;
+    private Map<Long, Integer> unreadCounts;
+    private Map<Long, Boolean> userStatus;
+
+
+    public static ChatRoomEntity create(Long sellerId, Long buyerId, Long productId, String productImage,
+                                        String productTitle, int price) {
+        Map<Long, Integer> unreadMap = Map.of(sellerId, 0, buyerId, 0);
+        Map<Long, Boolean> statusMap = Map.of(sellerId, true, buyerId, true);
+
+        ChatRoomEntity entity = new ChatRoomEntity();
+        entity.sellerId = Objects.requireNonNull(sellerId, "sellerId는 필수입니다.");
+        entity.buyerId = Objects.requireNonNull(buyerId, "buyerId는 필수입니다.");
+        entity.productId = Objects.requireNonNull(productId, "productId는 필수입니다.");
+        entity.productImage = productImage;
+        entity.productTitle = Objects.requireNonNull(productTitle);
+        entity.price = price;
+        entity.lastMessage = "거래 상대방과 대화해보세요 :)";
+        entity.lastMessageAt = LocalDateTime.now();
+        entity.createdAt = LocalDateTime.now();
+        entity.unreadCounts = unreadMap;
+        entity.userStatus = statusMap;
+
+        return entity;
+    }
+
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/repository/ChatMessageRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package org.j1p5.domain.chat.repository;
+
+import org.bson.types.ObjectId;
+import org.j1p5.domain.chat.entity.ChatMessageEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+
+public interface ChatMessageRepository extends MongoRepository<ChatMessageEntity, ObjectId> {
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/repository/ChatRoomRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,22 @@
+package org.j1p5.domain.chat.repository;
+
+import org.bson.types.ObjectId;
+import org.j1p5.domain.chat.entity.ChatRoomEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.List;
+
+public interface ChatRoomRepository extends MongoRepository<ChatRoomEntity, ObjectId> {
+    // 모든 채팅방 조회 (userId가 sellerId 또는 buyerId인 경우)
+    @Query(value = "{ '$or': [ { 'sellerId': ?0, 'userStatus.?0': true }, { 'buyerId': ?0, 'userStatus.?0': true } ] }", sort = "{ 'lastMessageAt': -1 }")
+    List<ChatRoomEntity> findAllByUserId(Long userId);
+
+    // sellerId인 경우만 조회
+    @Query(value = "{ 'sellerId': ?0, 'userStatus.?0': true }", sort = "{ 'lastMessageAt': -1 }")
+    List<ChatRoomEntity> findBySellerId(Long sellerId);
+
+    // buyerId인 경우만 조회
+    @Query(value = "{ 'buyerId': ?0, 'userStatus.?0' : true }", sort = "{ 'lastMessageAt': -1 }")
+    List<ChatRoomEntity> findByBuyerId(Long buyerId);
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/CommentRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,8 @@
 package org.j1p5.domain.comment.repository;
 
+import org.j1p5.domain.comment.entity.CommentEntity;
 import org.j1p5.domain.comment.repository.querydsl.CommentRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<CommentRepository,Long> , CommentRepositoryCustom {
+public interface CommentRepository extends JpaRepository<CommentEntity,Long> , CommentRepositoryCustom {
 }

--- a/meerket/meerket-domain/src/main/resources/application.yml
+++ b/meerket/meerket-domain/src/main/resources/application.yml
@@ -11,10 +11,19 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+#      ddl-auto: update
     show-sql: true # 실행되는 SQL 쿼리 표시
     properties:
       hibernate:
         format_sql: true # SQL 포맷팅
         dialect: org.hibernate.spatial.dialect.mysql.MySQLSpatialDialect
+
+
+  data:
+    mongodb:
+      uri: ${MONGO_URI}
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
 

--- a/meerket/meerket-infrastructure/build.gradle
+++ b/meerket/meerket-infrastructure/build.gradle
@@ -14,6 +14,11 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    // redis 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 }
 
 test {

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/config/RedisConfig.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package org.j1p5.infrastructure.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean(name = "redisTemplate")
+    public RedisTemplate<String, String> queueRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->
<br/>  #2 채팅 도메인 초기 설정

## 💭 작업 내용
<!-- 작업한 내용을 간단히 설명해주세요 -->
<br/> ChatRoomEntity, ChatMessageEntity, ChatRoomRepository, ChatMessageRepository 
mongodb, redis 설정 등 채팅 도메인의 기본 설정을 마쳤습니다.

## 🤔 참고 사항
<!-- 참고 사항을 설명해주세요 -->
<br/>
main class 위치변경을 커밋에 반영하지 않아서 빌드에 실패할 것 같습니다. 추후 성현님이 바꾸신 application클래스를 반영해야 할 것 같습니다.

일단 지금 메인 최상단 build.gradle에도 의존성을 추가했는데 domain 모듈의 build.gradle에서는 혹시나 충돌날것같아서 그대로 냅뒀습니다!

domain, application 둘다
    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
이게 추가 되어있는데 
application에서 곧바로 repository를 참조하려면 ObjectId 타입을 사용해야 하는데 mongodb를 infra 모듈에 두면 
인터페이스를 이용해서 조회할 수 있지만 현재처럼MongoDB가  Domain 모듈에 있어서 현재 JPA를 최상단 build.gradle에 둔것처럼 
spring-boot-starter-data-mongodb도 최상단에 두거나 아니면 application 모듈 domain 모듈 모두에서 의존해야할 것 같습니다.

일단은 그냥 application 모듈에도 추가했는데 논의 후 결정해야 할 듯 합니다!

