### PR TITLE
Feat/#23 chat service basic

### DIFF
--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/ChatRoomBasicInfo.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/ChatRoomBasicInfo.java
@@ -1,0 +1,25 @@
+package org.j1p5.api.chat.dto;
+
+
+import java.util.Objects;
+
+public record ChatRoomBasicInfo(
+        String roomId,
+        String otherNickname,
+        String otherProfileImage,
+        Long otherUserId,
+        Long productId,
+        String productTitle,
+        String productImage,
+        int price,
+        boolean isSeller
+
+) {
+    public ChatRoomBasicInfo{
+        Objects.requireNonNull(roomId,"roomId는 필수입니다.");
+        Objects.requireNonNull(otherNickname,"otherNickname은 필수입니다.");
+        Objects.requireNonNull(otherUserId,"otherUserId는 필수입니다.");
+        Objects.requireNonNull(productId,"productId는 필수입니다.");
+        Objects.requireNonNull(productTitle,"productTitle은 필수입니다.");
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/ChatRoomFilter.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/ChatRoomFilter.java
@@ -1,0 +1,7 @@
+package org.j1p5.api.chat.dto;
+
+public enum ChatRoomFilter {
+    ALL,
+    PURCHASE,
+    SALE
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/OtherProfile.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/OtherProfile.java
@@ -1,0 +1,15 @@
+package org.j1p5.api.chat.dto;
+
+import java.util.Objects;
+
+public record OtherProfile(
+        String otherNickname,
+        String otherProfileImage,
+        Long otherUserId
+) {
+
+    public OtherProfile{
+        Objects.requireNonNull(otherNickname, "닉네임은 필수입니다.");
+        Objects.requireNonNull(otherUserId, "id는 필수입니다.");
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/request/ChatMessageRequest.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,21 @@
+package org.j1p5.api.chat.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ChatMessageRequest(
+        @NotNull
+        @Size(min = 24, max = 24, message = "roomId는 24자여야 합니다.")
+        String roomId,
+
+        @NotNull
+        @Min(1)
+        Long receiverId,
+
+        @NotBlank(message = "메시지는 공백일 수 없습니다.")
+        @Size(max = 500, message = "메시지는 최대 500자까지 입력 가능합니다.")
+        String content
+) {
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/ChatMessageResponse.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,29 @@
+package org.j1p5.api.chat.dto.response;
+
+import org.j1p5.domain.chat.entity.ChatMessageEntity;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record ChatMessageResponse(
+        String id,
+        Long senderId,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static ChatMessageResponse fromEntity(ChatMessageEntity entity) {
+        return new ChatMessageResponse(
+                entity.getId().toString(),
+                entity.getSenderId(),
+                entity.getContent(),
+                entity.getCreatedAt());
+    }
+
+    public ChatMessageResponse{
+        Objects.requireNonNull(id, "id는 필수값입니다.");
+        Objects.requireNonNull(senderId, "senderId는 필수값입니다.");
+        Objects.requireNonNull(content, "내용은 필수 값입니다.");
+        Objects.requireNonNull(createdAt, "생성시간은 필수값입니다.");
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/ChatRoomEnterResponse.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/ChatRoomEnterResponse.java
@@ -1,0 +1,16 @@
+package org.j1p5.api.chat.dto.response;
+
+import org.j1p5.api.chat.dto.ChatRoomBasicInfo;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ChatRoomEnterResponse(
+        ChatRoomBasicInfo chatRoomBasicInfo,
+        List<ChatMessageResponse> messages
+) {
+    public ChatRoomEnterResponse{
+        Objects.requireNonNull(chatRoomBasicInfo, "채팅방 기본정보는 필수입니다.");
+        Objects.requireNonNull(messages, "메시지 리스트는 필수입니다.");
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/ChatRoomInfoResponse.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/ChatRoomInfoResponse.java
@@ -1,0 +1,24 @@
+package org.j1p5.api.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record ChatRoomInfoResponse(
+        String roomId,
+        String lastMessage,
+        LocalDateTime lastMessageAt,
+        Long productId,
+        int unreadCount,
+        String productImage,
+        String otherNickname,
+        String otherProfileImage
+) {
+
+    public ChatRoomInfoResponse{
+        Objects.requireNonNull(roomId, "roomId는 필수입니다.");
+        Objects.requireNonNull(lastMessage, "lastMessage는 필수입니다.");
+        Objects.requireNonNull(lastMessageAt, "lastMessageAt는 필수입니다.");
+        Objects.requireNonNull(productId, "productId는 필수입니다.");
+        Objects.requireNonNull(otherNickname, "otherNickname는 필수입니다.");
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/CreateChatRoomResponse.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/response/CreateChatRoomResponse.java
@@ -1,0 +1,11 @@
+package org.j1p5.api.chat.dto.response;
+
+import java.util.Objects;
+
+public record CreateChatRoomResponse(
+        String roomId
+) {
+    public CreateChatRoomResponse{
+        Objects.requireNonNull(roomId, "roomId는 필수입니다.");
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/ChatMessageService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/ChatMessageService.java
@@ -1,0 +1,58 @@
+package org.j1p5.api.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.j1p5.api.chat.dto.response.ChatMessageResponse;
+import org.j1p5.domain.chat.entity.ChatMessageEntity;
+import org.j1p5.domain.chat.repository.ChatMessageRepository;
+import org.springframework.boot.autoconfigure.mongo.StandardMongoClientSettingsBuilderCustomizer;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * @author yechan
+ */
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final MongoTemplate mongoTemplate;
+    private final StandardMongoClientSettingsBuilderCustomizer standardMongoSettingsCustomizer;
+
+    public ChatMessageEntity sendMessage(ObjectId roomId, Long senderId, String content) {
+        ChatMessageEntity chatMessageEntity = ChatMessageEntity.create(roomId, senderId, content);
+        try {
+            return chatMessageRepository.save(chatMessageEntity);
+        } catch (Exception e) { //TODO 추후 커스텀 예외 처리
+            throw new RuntimeException("메시지 저장에 실패했습니다.", e);
+        }
+    }
+
+
+    public List<ChatMessageResponse> getChatMessages(ObjectId roomObjectId, Long userId, LocalDateTime beforeTime) {
+
+        int limit = 30;
+        Query query = new Query();
+        query.addCriteria(Criteria.where("roomId").is(roomObjectId));
+
+        if (beforeTime != null) {
+            query.addCriteria(Criteria.where("createdAt").lt(beforeTime));
+        }
+
+        query.with(Sort.by(Sort.Direction.DESC, "createdAt")).limit(limit);
+
+        List<ChatMessageEntity> chatMessageEntities = mongoTemplate.find(query, ChatMessageEntity.class);
+        List<ChatMessageResponse> responses = chatMessageEntities.stream()
+                .map(ChatMessageResponse::fromEntity)
+                .toList();
+
+        return responses;
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/ChatMessageService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/ChatMessageService.java
@@ -24,7 +24,6 @@ public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final MongoTemplate mongoTemplate;
-    private final StandardMongoClientSettingsBuilderCustomizer standardMongoSettingsCustomizer;
 
     public ChatMessageEntity sendMessage(ObjectId roomId, Long senderId, String content) {
         ChatMessageEntity chatMessageEntity = ChatMessageEntity.create(roomId, senderId, content);

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/ChatRoomService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/ChatRoomService.java
@@ -1,0 +1,230 @@
+package org.j1p5.api.chat.service;
+
+import com.mongodb.client.result.UpdateResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.j1p5.api.chat.dto.ChatRoomBasicInfo;
+import org.j1p5.api.chat.dto.ChatRoomFilter;
+import org.j1p5.api.chat.dto.OtherProfile;
+import org.j1p5.api.chat.dto.response.ChatRoomInfoResponse;
+import org.j1p5.api.chat.dto.response.CreateChatRoomResponse;
+import org.j1p5.domain.chat.entity.ChatRoomEntity;
+import org.j1p5.domain.chat.repository.ChatRoomRepository;
+import org.j1p5.domain.product.entity.ProductEntity;
+import org.j1p5.domain.product.repository.ProductRepository;
+import org.j1p5.domain.user.entity.UserEntity;
+import org.j1p5.domain.user.repository.UserRepository;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.AccessDeniedException;
+import java.time.LocalDateTime;
+import java.util.*;
+
+/**
+ * @author yechan
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * 특정 채팅방에 유저가 속해있는지 확인
+     *
+     * @param userId
+     * @param roomId
+     * @throws AccessDeniedException
+     */
+    public void verifyAccess(Long userId, ObjectId roomId) throws AccessDeniedException {
+        ChatRoomEntity chatRoomEntity = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+
+        if (chatRoomEntity.getSellerId() != userId && chatRoomEntity.getBuyerId() != userId) {
+            //TODO 예외처리 추가하기
+            throw new AccessDeniedException("해당 채팅방에 속한 유저가 아닙니다.");
+        }
+    }
+
+    /**
+     * String 타입의 roomId 검증 후 ObjectId로 반환
+     *
+     * @param roomId
+     * @return
+     */
+    public ObjectId validateRoomId(String roomId) {
+        if (!ObjectId.isValid(roomId)) {
+            throw new IllegalArgumentException("roomId 형식이 맞지않습니다.");
+        }
+        return new ObjectId(roomId);
+    }
+
+    public void updateChatRoomInfo(ObjectId roomId, String content, Long receiverId
+            , boolean receiverInChatRoom, LocalDateTime createdAt) {
+
+        Query query = new Query(Criteria.where("_id").is(roomId));
+        Update update = new Update()
+                .set("lastMessage", content)
+                .set("lastMessageAt", createdAt);
+
+        if (!receiverInChatRoom) {
+            update.inc("unreadCounts." + receiverId, 1);
+        }
+
+        try {
+            mongoTemplate.updateFirst(query, update, ChatRoomEntity.class);
+        } catch (Exception e) { //TODO 커스텀 예외 처리
+            log.error("채팅방 업데이트 실패");
+            throw new RuntimeException("채팅방 업데이트에 실패");
+        }
+    }
+
+    public boolean isReceiverInChatRoom(ObjectId roomId, Long receiverId) {
+        //TODO redis를 이용해서 있는지 없는지 확인
+        return true;
+    }
+
+
+    public List<ChatRoomInfoResponse> getUserChatRooms(Long userId, ChatRoomFilter filter) {
+        //TODO 커스텀 예외 처리
+        List<ChatRoomEntity> chatRoomEntities;
+        try {
+            chatRoomEntities = switch (filter) {
+                case ALL -> chatRoomRepository.findAllByUserId(userId);
+                case PURCHASE -> chatRoomRepository.findByBuyerId(userId);
+                case SALE -> chatRoomRepository.findBySellerId(userId);
+                default -> throw new IllegalArgumentException("잘못된 필터입력입니다."); //TODO 추후 예외처리
+            };
+
+            List<ChatRoomInfoResponse> chatRoomInfoResponses = new ArrayList<>();
+            for (ChatRoomEntity chatRoomEntity : chatRoomEntities) {
+                OtherProfile otherProfile = getOtherProfile(chatRoomEntity, userId);
+
+                ChatRoomInfoResponse response = new ChatRoomInfoResponse(
+                        chatRoomEntity.getId().toString(),
+                        chatRoomEntity.getLastMessage(),
+                        chatRoomEntity.getLastMessageAt(),
+                        chatRoomEntity.getProductId(),
+                        chatRoomEntity.getUnreadCounts().getOrDefault(userId, 0),
+                        chatRoomEntity.getProductImage(),
+                        otherProfile.otherNickname(),
+                        otherProfile.otherProfileImage()
+                );
+
+                chatRoomInfoResponses.add(response);
+            }
+            return chatRoomInfoResponses;
+
+        } catch (DataAccessException e) {
+            log.error("채팅방 목록 조회중 에러 발생", e);
+            throw new RuntimeException("채팅방 조회중 에러 발생");
+        }
+    }
+
+
+    public CreateChatRoomResponse createChatRoom(Long userId, Long productId) {
+        //TODO 낙찰자, 구매자 찾는과정 필요
+        // 지금은 userId == sellerId 이고 otherUserId == buyerId 라고 가정
+        Long otherUserId = 2L;
+
+        Map<Long, Integer> unreadCountsMap = Map.of(userId, 0, otherUserId, 0);
+        Map<Long, Boolean> statusMap = Map.of(userId, true, otherUserId, true);
+
+        //TODO 대표이미지, 낙찰가는 아직 product 테이블에 반영x
+        int successfulBid = 100000;
+
+        ProductEntity productEntity = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 물건이 존재하지않습니다."));
+
+        ChatRoomEntity chatRoomEntity = ChatRoomEntity.create(userId, otherUserId, productId,
+                "productImage", productEntity.getTitle(), successfulBid);
+
+        chatRoomRepository.save(chatRoomEntity);
+
+        CreateChatRoomResponse response = new CreateChatRoomResponse(chatRoomEntity.getId().toString());
+        return response;
+    }
+
+
+    public void exitChatRoom(Long userId, ObjectId roomId) {
+        //TODO 커스텀 예외 처리
+        try {
+            Query query = new Query(Criteria.where("_id").is(roomId));
+            Update update = new Update().set("userStatus." + userId, false);
+
+            mongoTemplate.updateFirst(query, update, ChatRoomEntity.class);
+        } catch (Exception e) {
+            throw new RuntimeException("채팅방에서 나가기 중 예외 발생");
+        }
+    }
+
+
+    public void resetUnreadCount(ObjectId roomObjectId, Long userId) {
+        //TODO 커스텀 예외처리
+        try {
+            Query query = new Query(Criteria.where("_id").is(roomObjectId));
+            Update update = new Update().set("unreadCounts." + userId, 0);
+            UpdateResult result = mongoTemplate.updateFirst(query, update, ChatRoomEntity.class);
+
+            if (result.getMatchedCount() == 0) {
+                throw new IllegalArgumentException("해당 채팅방이 존재하지 않습니다.");
+            }
+        } catch (DataAccessException e) {
+            throw new RuntimeException("안 읽은 메시지 카운트 초기화 중 오류가 발생", e);
+        }
+    }
+
+    public ChatRoomBasicInfo getChatRoomBasicInfo(ObjectId roomObjectId, Long userId) {
+        ChatRoomEntity chatRoomEntity = chatRoomRepository.findById(roomObjectId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
+
+
+        OtherProfile otherProfile = getOtherProfile(chatRoomEntity, userId);
+        boolean isSeller = chatRoomEntity.getSellerId() == userId;
+
+        return new ChatRoomBasicInfo(
+                chatRoomEntity.getId().toString(),
+                otherProfile.otherNickname(),
+                otherProfile.otherProfileImage(),
+                otherProfile.otherUserId(),
+                chatRoomEntity.getProductId(),
+                chatRoomEntity.getProductTitle(),
+                chatRoomEntity.getProductImage(),
+                chatRoomEntity.getPrice(),
+                isSeller
+        );
+
+    }
+
+
+    // 상대방 프로필 확인
+    private OtherProfile getOtherProfile(ChatRoomEntity chatRoomEntity, Long userId) {
+        Long otherUserId = userId == chatRoomEntity.getSellerId()
+                ? chatRoomEntity.getBuyerId()
+                : chatRoomEntity.getSellerId();
+
+        UserEntity userEntity = userRepository.findById(otherUserId) //TODO 추후 예외처리
+                .orElseThrow(() -> new NoSuchElementException("해당 유저가 존재하지 않습니다."));
+
+        return new OtherProfile(userEntity.getNickname(), userEntity.getImageUrl(), userEntity.getId());
+
+    }
+
+
+}
+
+
+
+
+
+

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/CreateChatRoomUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/CreateChatRoomUseCase.java
@@ -1,0 +1,21 @@
+package org.j1p5.api.chat.service.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.j1p5.api.chat.dto.response.CreateChatRoomResponse;
+import org.j1p5.api.chat.service.ChatRoomService;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author yechan
+ * 낙찰자와 판매자 1대1 채팅방 생성
+ */
+@Service
+@RequiredArgsConstructor
+public class CreateChatRoomUseCase {
+
+    private final ChatRoomService chatRoomService;
+
+    public CreateChatRoomResponse execute(Long userId, Long productId) {
+        return chatRoomService.createChatRoom(userId, productId);
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/EnterChatRoomUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/EnterChatRoomUseCase.java
@@ -1,0 +1,39 @@
+package org.j1p5.api.chat.service.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.j1p5.api.chat.dto.ChatRoomBasicInfo;
+import org.j1p5.api.chat.dto.response.ChatMessageResponse;
+import org.j1p5.api.chat.dto.response.ChatRoomEnterResponse;
+import org.j1p5.api.chat.service.ChatMessageService;
+import org.j1p5.api.chat.service.ChatRoomService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * @author yechan
+ * 특정 채팅방에 입장했을때 여러 채팅 정보들 제공
+ */
+@Service
+@RequiredArgsConstructor
+public class EnterChatRoomUseCase {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+
+    public ChatRoomEnterResponse execute(Long userId, String roomId) {
+
+        ObjectId roomObjectId = chatRoomService.validateRoomId(roomId);
+
+        chatRoomService.resetUnreadCount(roomObjectId, userId);
+
+        List<ChatMessageResponse> chatMessages = chatMessageService.getChatMessages(roomObjectId, userId, null);
+
+        ChatRoomBasicInfo chatRoomBasicInfo = chatRoomService.getChatRoomBasicInfo(roomObjectId, userId);
+
+        return new ChatRoomEnterResponse(chatRoomBasicInfo, chatMessages);
+    }
+
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/ExitChatRoomUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/ExitChatRoomUseCase.java
@@ -1,0 +1,27 @@
+package org.j1p5.api.chat.service.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.j1p5.api.chat.service.ChatRoomService;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.AccessDeniedException;
+
+/**
+ * @author yechan
+ * 채팅방에서 나갔을때 채팅방의 활성 유저 상태 변경
+ */
+@Service
+@RequiredArgsConstructor
+public class ExitChatRoomUseCase {
+
+    private final ChatRoomService chatRoomService;
+
+    public void execute(Long userId, String roomId) throws AccessDeniedException {
+        ObjectId roomObjectId = chatRoomService.validateRoomId(roomId);
+
+        chatRoomService.verifyAccess(userId, roomObjectId);
+
+        chatRoomService.exitChatRoom(userId, roomObjectId);
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/GetChatMessageUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/GetChatMessageUseCase.java
@@ -1,0 +1,34 @@
+package org.j1p5.api.chat.service.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.j1p5.api.chat.dto.response.ChatMessageResponse;
+import org.j1p5.api.chat.service.ChatMessageService;
+import org.j1p5.api.chat.service.ChatRoomService;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.AccessDeniedException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * @author yechan
+ * 채팅 메시지를 불러옴 넘겨받은 가장 오래된 메시지 시간 기준 30개
+ */
+@Service
+@RequiredArgsConstructor
+public class GetChatMessageUseCase {
+
+    private final ChatMessageService chatMessageService;
+    private final ChatRoomService chatRoomService;
+
+    public List<ChatMessageResponse> execute(String roomId, LocalDateTime beforeTime, Long userId) throws AccessDeniedException {
+
+        ObjectId roomObjectId = chatRoomService.validateRoomId(roomId);
+
+        chatRoomService.verifyAccess(userId, roomObjectId);
+
+        return chatMessageService.getChatMessages(roomObjectId, userId, beforeTime);
+    }
+
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/GetUserChatRoomsUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/GetUserChatRoomsUseCase.java
@@ -1,0 +1,24 @@
+package org.j1p5.api.chat.service.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.j1p5.api.chat.dto.ChatRoomFilter;
+import org.j1p5.api.chat.dto.response.ChatRoomInfoResponse;
+import org.j1p5.api.chat.service.ChatRoomService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * @author yechan
+ * 유저가 속한 채팅방 목록 조회
+ */
+@Service
+@RequiredArgsConstructor
+public class GetUserChatRoomsUseCase {
+
+    private final ChatRoomService chatRoomService;
+
+    public List<ChatRoomInfoResponse> execute(Long userId, ChatRoomFilter filter) {
+        return chatRoomService.getUserChatRooms(userId, filter);
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/SendChatMessageUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/SendChatMessageUseCase.java
@@ -1,0 +1,46 @@
+package org.j1p5.api.chat.service.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.j1p5.api.chat.dto.response.ChatMessageResponse;
+import org.j1p5.api.chat.service.ChatMessageService;
+import org.j1p5.api.chat.service.ChatRoomService;
+import org.j1p5.domain.chat.entity.ChatMessageEntity;
+import org.springframework.stereotype.Service;
+import org.bson.types.ObjectId;
+
+import java.nio.file.AccessDeniedException;
+
+/**
+ * 메시지를 보냈을때 메시지 저장과 채팅방 상태 업데이트
+ */
+@Service
+@RequiredArgsConstructor
+public class SendChatMessageUseCase {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+    // 메시지 보내기
+    //@Transactional 추후 적용
+    public ChatMessageResponse execute(
+            Long userId, Long receiverId, String content, String roomId) throws AccessDeniedException {
+
+        ObjectId roomObjectId = chatRoomService.validateRoomId(roomId);
+
+        chatRoomService.verifyAccess(userId, roomObjectId);
+
+        ChatMessageEntity chatMessageEntity = chatMessageService.sendMessage(roomObjectId, userId, content);
+
+        boolean receiverInChatRoom = chatRoomService.isReceiverInChatRoom(roomObjectId, receiverId);
+
+        chatRoomService.updateChatRoomInfo(
+                roomObjectId, content,
+                receiverId, receiverInChatRoom, chatMessageEntity.getCreatedAt());
+
+        // FCM 전송 등 추가 작업
+        //TODO
+        return ChatMessageResponse.fromEntity(chatMessageEntity);
+    }
+
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->
<br/> #23 

## 💭 작업 내용
<!-- 작업한 내용을 간단히 설명해주세요 -->
<br/> 
채팅과 관련해서 각각 UseCase를 작성하고 구현 Service로 ChatRoomService, ChatMessageService를 구현했습니다.

## 🤔 참고 사항
<!-- 참고 사항을 설명해주세요 -->
<br/>
멀티모듈과 채팅 모두 익숙하지않아 팀 프로젝트에 바로 코드를 작성하기 전에 따로 프로젝트를 하나 파서 단일모듈로 채팅을 구현하고,
그것을 팀프로젝트에 옮기는 작업을 하고 있습니다. 그래서 부득이하게 pr의 크기가 너무 커질듯하여 UseCase와 Service클래스 먼저 올리게 되었습니다.

@Transactional을 mongodb에서 사용하려면 replica set 과 같은 환경구성이 필요하다고 하여 현재는 미적용 상태입니다!
또한 커스텀 예외처리는 이후 적용 예정입니다!


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
UseCase하나에 공개메서드를 하나만 두고 하위 구현 Service들을 의존하는 현재의 구조가 올바른 구조인지 궁금합니다! 
또한 그 외에 데이터의 흐름이나 코드에서 개선해야 할 부분들이 있는지 궁금합니다!

