### PR TITLE
[Hotfix] 유저 프로필 수정 오류, 읍면동 테이블 오류 수정

### DIFF
--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/service/UserProfileService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/service/UserProfileService.java
@@ -23,18 +23,18 @@ public class UserProfileService {
 
     @Transactional
     public void updateNickname(Long userId, String nickname) {
-        nickNameValidation(nickname);
-
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+        nickNameValidation(user, nickname);
 
         user.updateNickname(nickname);
     }
 
-    public void nickNameValidation(String nickname) {
+    public void nickNameValidation(UserEntity user, String nickname) {
         boolean isExist = userRepository.existsByNickname(nickname);
 
-        if (isExist) {
+        if (isExist && !nickname.equals(user.getNickname())) {
             throw new NicknameAlreadyExistException(NICKNAME_ALREADY_EXIST);
         }
     }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/EmdArea.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/EmdArea.java
@@ -2,6 +2,8 @@ package org.j1p5.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 
@@ -18,10 +20,10 @@ public class EmdArea {
     @Column(name = "emd_name", nullable = false, length = 20)
     private String emdName;
 
-    @Column(name = "geom", nullable = false)
-    private Polygon geom;
+    @Column(name = "geom", nullable = false, columnDefinition = "geometry(MULTIPOLYGON)")
+    private Geometry geom;
 
-    @Column(name = "coordinate", nullable = false)
+    @Column(name = "coordinate", nullable = false, columnDefinition = "geometry(POINT)")
     private Point coordinate;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 📌 관련 이슈
#116 
<br/>

## 💭 작업 내용
- 사용자가 이미지만 바꾸고 싶을 때 닉네임 중복 오류 발생 수정.
- 사용자 닉네임이 들어온 닉네임과 일치 시 유효성 검사 통과하게 수정.
- 읍면동 테이블에 폴리곤, 멀티폴리곤 두 형태가 있는데 코드에서는 폴리곤으로만 받고 있었음
- 두 개의 형태를 포괄하는 Geometry 형태로 수정하여 해결.
<br/>

## 🤔 참고 사항
- Geometry형태는 Point 등 여러 형태를 포함하고 있어 geom 필드에 폴리곤 혹은 멀티폴리곤 형태만 들어오도록 로직을 작성해야 함.
- 추후 geom 필드에 폴리곤 혹은 멀티폴리곤 단일 형태만 들어올 수 있도록 수정하는 것이 좋을 것 같습니다.
- 이걸 위해서 mysql보다 공간 함수에 대해 더 넓게 지원해주는 postgreSQL(postGIS 사용 가능)으로 가야할 것 같아요
<br/>

## 📸 스크린샷(선택)
<br/>

## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
