### PR TITLE
Feat/#127 completed auction

### DIFF
--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/controller/ChatController.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/controller/ChatController.java
@@ -15,6 +15,7 @@ import org.j1p5.api.global.annotation.LoginUser;
 import org.j1p5.api.global.response.Response;
 import org.j1p5.domain.chat.vo.MessageInfo;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -115,7 +116,7 @@ public class ChatController {
     )
     @MessageMapping("/message")
     public Response<Void> sendChatMessage(
-            @RequestBody @Validated ChatMessageRequest request
+            @Payload @Validated ChatMessageRequest request
     ) {
 
         MessageInfo messageInfo = new MessageInfo(

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/ChatRoomBasicInfo.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/dto/ChatRoomBasicInfo.java
@@ -1,6 +1,8 @@
 package org.j1p5.api.chat.dto;
 
 
+import org.j1p5.domain.product.entity.ProductStatus;
+
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -16,7 +18,8 @@ public record ChatRoomBasicInfo(
         boolean isSeller,
         boolean isChatAvailable,
         String sellerAddress,
-        LocalDateTime productCreatedAt
+        LocalDateTime productCreatedAt,
+        ProductStatus productStatus
 ) {
     public ChatRoomBasicInfo{
         Objects.requireNonNull(roomId,"roomId는 필수입니다.");
@@ -27,6 +30,7 @@ public record ChatRoomBasicInfo(
         Objects.requireNonNull(isChatAvailable, "isChatAvailable은 필수입니다.");
         Objects.requireNonNull(sellerAddress, "sellerAddress 는 필수입니다.");
         Objects.requireNonNull(productCreatedAt, "productCreatedAt 은 필수입니다.");
+        Objects.requireNonNull(productStatus, "productStatus는 필수입니다.");
 
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/EnterChatRoomUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/EnterChatRoomUseCase.java
@@ -73,7 +73,8 @@ public class EnterChatRoomUseCase {
                 isSeller,
                 chatRoomEntity.isChatAvailable(),
                 EmdNameReader.getEmdName(productEntity.getUser()),
-                productEntity.getCreatedAt()
+                productEntity.getCreatedAt(),
+                productEntity.getStatus()
         );
     }
 

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/controller/ProductController.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/controller/ProductController.java
@@ -90,6 +90,7 @@ public class ProductController {
         return Response.onSuccess(products);
     }
 
+
     @GetMapping("/{productId}")
     public Response<ProductResponseDetailInfo> getProductDetails(
             @PathVariable(name = "productId") Long productId, @LoginUser Long userId) {
@@ -116,23 +117,23 @@ public class ProductController {
 
     @GetMapping("/categories")
     public Response<CursorResult<ProductResponseInfo>> getProductByCategory(@RequestParam(name = "category") String category,
-                                                                            @LoginUser Long userId,@CursorDefault Cursor cursor){
+                                                                            @LoginUser Long userId, @CursorDefault Cursor cursor) {
 
-        return Response.onSuccess(productService.getProductsByCategory(userId,cursor,category));
+        return Response.onSuccess(productService.getProductsByCategory(userId, cursor, category));
     }
 
     @GetMapping("/my")
     public Response<CursorResult<MyProductResponseDto>> getMyProducts(@LoginUser Long userId,
                                                                       @CursorDefault Cursor cursor,
-                                                                      @RequestParam(name = "status")ProductStatus status
-                                                                      ){
-        return Response.onSuccess(productService.getMyProducts(userId,cursor,status));
+                                                                      @RequestParam(name = "status") ProductStatus status
+    ) {
+        return Response.onSuccess(productService.getMyProducts(userId, cursor, status));
     }
 
     @GetMapping("/keywords")
     private Response<CursorResult<ProductResponseInfo>> getProductByKeyword(@RequestParam(name = "keyword") String keyword,
                                                                             @LoginUser Long userId,
-                                                                            @CursorDefault Cursor cursor){
+                                                                            @CursorDefault Cursor cursor) {
 
         return Response.onSuccess(productService.getProductByKeyword(keyword, userId, cursor));
 
@@ -141,10 +142,19 @@ public class ProductController {
 
     @PostMapping("/{productId}/early-close")
     public Response<CloseEarlyResponseDto> closeEarly(@PathVariable(name = "productId") Long productId,
-                                                      @LoginUser Long userId){
-        return Response.onSuccess(productService.closeProductEarly(productId,userId));
-
-
-
+                                                      @LoginUser Long userId) {
+        return Response.onSuccess(productService.closeProductEarly(productId, userId));
     }
+
+
+    @PatchMapping("/{productId}/complete")
+    public Response<Void> markProductAsCompleted(
+            @PathVariable Long productId,
+            @LoginUser Long userId
+    ) {
+
+        productService.markProductAsCompleted(productId, userId);
+        return Response.onSuccess();
+    }
+
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/controller/ProductController.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/controller/ProductController.java
@@ -90,10 +90,22 @@ public class ProductController {
         return Response.onSuccess(products);
     }
 
+    @GetMapping("/completed")
+    public Response<CursorResult<ProductResponseInfo>> getCompletedProducts(
+            @CursorDefault Cursor cursor,
+            @LoginUser Long userId
+    ) {
+
+        CursorResult<ProductResponseInfo> completedProducts = productService.getCompletedProducts(userId, cursor);
+
+        return Response.onSuccess(completedProducts);
+    }
+
 
     @GetMapping("/{productId}")
     public Response<ProductResponseDetailInfo> getProductDetails(
             @PathVariable(name = "productId") Long productId, @LoginUser Long userId) {
+
         return Response.onSuccess(productService.getProductDetail(productId, userId));
     }
 
@@ -156,5 +168,10 @@ public class ProductController {
         productService.markProductAsCompleted(productId, userId);
         return Response.onSuccess();
     }
+
+
+
+
+
 
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
@@ -10,6 +10,7 @@ import org.j1p5.api.global.excpetion.WebException;
 import org.j1p5.api.product.dto.response.CloseEarlyResponseDto;
 import org.j1p5.api.product.dto.response.CreateProductResponseDto;
 import org.j1p5.api.product.dto.response.MyProductResponseDto;
+import org.j1p5.api.product.exception.ProductException;
 import org.j1p5.common.dto.Cursor;
 import org.j1p5.common.dto.CursorResult;
 import org.j1p5.domain.activityArea.entity.ActivityArea;
@@ -272,6 +273,27 @@ public class ProductService {
         ));
         productEntity.updateStatusToInProgress();
 
+    }
+
+
+    // 거래 완료를 눌렀을때 물품의 상태를 변경하는것
+    @Transactional
+    public void markProductAsCompleted(Long productId, Long userId) {
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new WebException(USER_NOT_FOUND));
+
+        ProductEntity productEntity = productRepository.findById(productId)
+                .orElseThrow(() -> new WebException(PRODUCT_NOT_FOUND));
+
+        if (!productEntity.getUser().getId().equals(userEntity.getId())) {
+            throw new WebException(PRODUCT_NOT_AUTHORIZED);
+        }
+
+        if(!productEntity.isHasBuyer()){
+            throw new WebException(PRODUCT_HAS_NO_BUYER);
+        }
+
+        productEntity.updateStatusToComplete();
     }
 
 

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
@@ -10,7 +10,6 @@ import org.j1p5.api.global.excpetion.WebException;
 import org.j1p5.api.product.dto.response.CloseEarlyResponseDto;
 import org.j1p5.api.product.dto.response.CreateProductResponseDto;
 import org.j1p5.api.product.dto.response.MyProductResponseDto;
-import org.j1p5.api.product.exception.ProductException;
 import org.j1p5.common.dto.Cursor;
 import org.j1p5.common.dto.CursorResult;
 import org.j1p5.domain.activityArea.entity.ActivityArea;
@@ -110,6 +109,35 @@ public class ProductService {
 
         return CursorResult.of(productResponseInfos, nextCursor); // Dto ->CursorResult형으로 변환
     }
+
+    // 마감 된 상품만 따로 조회(임시 시세 조회 api)
+    //TODO 추후 리팩토링(위에 getProducts랑 겹치는 부분)
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
+    public CursorResult<ProductResponseInfo> getCompletedProducts(Long userId, Cursor cursor) {
+
+        UserEntity user = userReader.getUser(userId);
+
+        List<ActivityArea> activityAreas = user.getActivityAreas();
+        Point coordinate = activityAreaReader.getActivityArea(activityAreas);
+
+        List<ProductEntity> products = productRepository
+                .findCompletedProductsByCursor(coordinate, cursor.cursor(), cursor.size());
+
+        Long nextCursor = products.isEmpty() ? null : products.get(products.size() - 1).getId();
+
+        List<ProductResponseInfo> productResponseInfos = products.stream()
+                .map(product -> {
+                    MyLocationInfo myLocationInfo = MyLocationInfo
+                            .of(userLocationNameReader.getLocationName(activityAreas.get(0)));
+                    return ProductResponseInfo.from(product, myLocationInfo);
+                })
+                .toList();
+
+        return CursorResult.of(productResponseInfos, nextCursor);
+    }
+
+
+
 
     @Transactional
     public ProductResponseDetailInfo getProductDetail(Long productId, Long userId) {

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/entity/ProductEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/entity/ProductEntity.java
@@ -138,4 +138,11 @@ public class ProductEntity extends BaseEntity {
     public void updateHasBuyer(){this.hasBuyer = true;}
 
     public void updateHasBuyerFalse(){this.hasBuyer = false;}
+
+
+    public void updateStatusToComplete() {
+        this.status = ProductStatus.COMPLETED;
+    }
+
+
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustom.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustom.java
@@ -9,6 +9,8 @@ public interface ProductRepositoryCustom {
 
     List<ProductEntity> findProductsByCursor(Point coordinate, Long cursor, Integer size);
 
+    List<ProductEntity> findCompletedProductsByCursor(Point coordinate, Long cursor, Integer size);
+
     List<ProductEntity> findProductByCategory(Point coordinate,String category, Long cursor, Integer size);
 
     List<ProductEntity> findProductByUserId(Long userId, Long cursor, Integer size, ProductStatus status);

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
@@ -38,6 +38,22 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                 .fetch();
     }
 
+    // 마감된 물품만 조회 (임시 시세조회 api)
+    @Override
+    public List<ProductEntity> findCompletedProductsByCursor(Point coordinate, Long cursor, Integer size) {
+        return queryFactory
+                .selectFrom(qProduct)
+                .where(
+                        withinDistance(coordinate, MAX_DISTANCE),
+                        cursorCondition(cursor),
+                        isNotDeleted(),
+                        qProduct.status.eq(ProductStatus.COMPLETED)
+                )
+                .orderBy(qProduct.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
     @Override
     public List<ProductEntity> findProductByCategory(Point coordinate, String category, Long cursor, Integer size) {
         return queryFactory.selectFrom(qProduct)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->
<br/> #127 

## 💭 작업 내용
<!-- 작업한 내용을 간단히 설명해주세요 -->
<br/> 시세조회를 위한 마감된 물품의 조회 api를 임시로 구현했습니다.
채팅방에서 판매자가 거래완료를 눌렀을때 해당 물품의 status가 COMPLETED로 변경되도록 구현했습니다.

## 🤔 참고 사항
<!-- 참고 사항을 설명해주세요 -->
<br/> 시세조회 부분은 임시적인 api 이고 또 성현님이 구현해놓으신 getProducts 와 겹치는곳이 많아 추후 리팩토링을 진행해야 할 것 같습니다.
또 Tranactional 의 import가 jakarta로 되어있는데 write가 아닌 read만 하는 경우 readOnly 옵션을 사용하는게 성능상 좋다고 하여 이 옵션을 사용할 수 있는 spring 라이브러리를 사용하였습니다.

