### PR TITLE
[Refactor] 유저 차단 후 조회 필터링

### DIFF
--- a/meerket/meerket-application/src/main/java/org/j1p5/api/comment/dto/response/CommentReadResponseDto.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/comment/dto/response/CommentReadResponseDto.java
@@ -1,6 +1,7 @@
 package org.j1p5.api.comment.dto.response;
 
 import org.j1p5.api.comment.dto.CommentMemeberDto;
+import org.j1p5.domain.comment.CommentInfo;
 import org.j1p5.domain.comment.entity.CommentEntity;
 import org.j1p5.domain.comment.entity.CommentStatus;
 import org.j1p5.domain.user.entity.UserEntity;
@@ -13,25 +14,26 @@ public record CommentReadResponseDto(
         CommentMemeberDto commentMemeberDto,
         Long commentId,
         String content,
+        boolean isBlocked,
         boolean isSeller,//판매자인지
         boolean isUpdatable,//수정된 글인지
         LocalDateTime createdAt,
         List<CommentReadResponseDto> replies,
         CommentStatus status
 ) {
-    public static CommentReadResponseDto of(CommentEntity commentEntity,UserEntity user){
-        boolean isUpdated = commentEntity.getStatus().equals(CommentStatus.UPDATED);//수정여부 판단하기 위해
+    public static CommentReadResponseDto of(CommentInfo commentInfo){
         return new CommentReadResponseDto(
-                new CommentMemeberDto(user.getNickname(),user.getImageUrl()),
-                commentEntity.getId(),
-                commentEntity.getContent(),
-                false,
-                isUpdated,
-                commentEntity.getCreatedAt(),
-                commentEntity.getReplies().stream()
-                        .map(reply -> CommentReadResponseDto.of(reply,reply.getUser()))
+                new CommentMemeberDto(commentInfo.userNickname(), commentInfo.userProfileImage()),
+                commentInfo.commentId(),
+                commentInfo.content(),
+                commentInfo.isBlocked(),
+                commentInfo.isSeller(),
+                commentInfo.isUpdatable(),
+                commentInfo.createdAt(),
+                commentInfo.replies().stream()
+                        .map(CommentReadResponseDto::of)
                         .collect(Collectors.toList()),
-                commentEntity.getStatus()
+                commentInfo.status()
         );
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/comment/service/CommentService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import org.j1p5.api.comment.dto.request.CommentUpdateRequestDto;
 import org.j1p5.api.global.excpetion.WebException;
 import org.j1p5.domain.block.entity.BlockEntity;
 import org.j1p5.domain.block.repository.BlockRepository;
+import org.j1p5.domain.comment.CommentInfo;
 import org.j1p5.domain.comment.entity.CommentEntity;
 import org.j1p5.domain.comment.repository.CommentRepository;
 import org.j1p5.domain.global.exception.DomainException;
@@ -65,11 +66,17 @@ public class CommentService {
         return comment;
     }
 
-    public List<CommentEntity> getComments(UserEntity user, Long productId, Pageable pageable) {
+    public List<CommentInfo> getComments(UserEntity user, Long productId, Pageable pageable) {
         List<Long> blockUserIds = blockRepository.findByUser(user)
                 .stream().map(b -> b.getBlockedUser().getId()).toList();
 
-        return commentRepository.findParentCommentByProductId(blockUserIds, productId, pageable);
+        List<CommentEntity> comments = commentRepository.findParentCommentByProductId(productId, pageable);
+
+        Long sellerId = getProduct(productId).getUser().getId();
+
+        return comments.stream()
+                .map(c -> CommentInfo.of(c, blockUserIds, sellerId))
+                .toList();
     }
 
     public void validateCommentUpdate(Long commentId, Long userId,CommentUpdateRequestDto request) {

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/comment/service/CommentService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/comment/service/CommentService.java
@@ -3,6 +3,8 @@ package org.j1p5.api.comment.service;
 import lombok.RequiredArgsConstructor;
 import org.j1p5.api.comment.dto.request.CommentUpdateRequestDto;
 import org.j1p5.api.global.excpetion.WebException;
+import org.j1p5.domain.block.entity.BlockEntity;
+import org.j1p5.domain.block.repository.BlockRepository;
 import org.j1p5.domain.comment.entity.CommentEntity;
 import org.j1p5.domain.comment.repository.CommentRepository;
 import org.j1p5.domain.global.exception.DomainException;
@@ -26,6 +28,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final ProductRepository productRepository;
     private final UserReader userReader;
+    private final BlockRepository blockRepository;
 
     public void appendComment(CommentEntity comment){
         commentRepository.save(comment);
@@ -62,8 +65,11 @@ public class CommentService {
         return comment;
     }
 
-    public List<CommentEntity> getComments(Long productId, Pageable pageable) {
-        return commentRepository.findParentCommentByProductId(productId, pageable);
+    public List<CommentEntity> getComments(UserEntity user, Long productId, Pageable pageable) {
+        List<Long> blockUserIds = blockRepository.findByUser(user)
+                .stream().map(b -> b.getBlockedUser().getId()).toList();
+
+        return commentRepository.findParentCommentByProductId(blockUserIds, productId, pageable);
     }
 
     public void validateCommentUpdate(Long commentId, Long userId,CommentUpdateRequestDto request) {

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/comment/usecase/CommentReadUsecase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/comment/usecase/CommentReadUsecase.java
@@ -25,7 +25,7 @@ public class CommentReadUsecase {
 
         UserEntity user = commentService.getUser(userId);
 
-        List<CommentEntity> commentEntityList = commentService.getComments(productId,pageable); //일단 부모 댓글만 가져오기
+        List<CommentEntity> commentEntityList = commentService.getComments(user, productId,pageable); //일단 부모 댓글만 가져오기
         //엔티티 dto로 변환return CommentReadResponseDto.of().str
         return commentEntityList.stream()
                 .map(commentEntity -> CommentReadResponseDto.of(commentEntity,commentEntity.getUser()))

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/comment/usecase/CommentReadUsecase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/comment/usecase/CommentReadUsecase.java
@@ -3,6 +3,7 @@ package org.j1p5.api.comment.usecase;
 import lombok.RequiredArgsConstructor;
 import org.j1p5.api.comment.dto.response.CommentReadResponseDto;
 import org.j1p5.api.comment.service.CommentService;
+import org.j1p5.domain.comment.CommentInfo;
 import org.j1p5.domain.comment.entity.CommentEntity;
 import org.j1p5.domain.product.entity.ProductEntity;
 import org.j1p5.domain.user.entity.UserEntity;
@@ -25,10 +26,10 @@ public class CommentReadUsecase {
 
         UserEntity user = commentService.getUser(userId);
 
-        List<CommentEntity> commentEntityList = commentService.getComments(user, productId,pageable); //일단 부모 댓글만 가져오기
+        List<CommentInfo> commentInfos = commentService.getComments(user, productId,pageable); //일단 부모 댓글만 가져오기
         //엔티티 dto로 변환return CommentReadResponseDto.of().str
-        return commentEntityList.stream()
-                .map(commentEntity -> CommentReadResponseDto.of(commentEntity,commentEntity.getUser()))
+        return commentInfos.stream()
+                .map(c -> CommentReadResponseDto.of(c))
                 .collect(Collectors.toList());
     }
 

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
@@ -16,6 +16,7 @@ import org.j1p5.common.dto.CursorResult;
 import org.j1p5.domain.activityArea.entity.ActivityArea;
 import org.j1p5.domain.auction.entity.AuctionEntity;
 import org.j1p5.domain.auction.repository.AuctionRepository;
+import org.j1p5.domain.block.repository.BlockRepository;
 import org.j1p5.domain.global.exception.DomainException;
 import org.j1p5.domain.image.entitiy.ImageEntity;
 import org.j1p5.domain.product.dto.*;
@@ -57,6 +58,7 @@ public class ProductService {
     private final AuctionRepository auctionRepository;
     private final QuartzService quartzService;
     private final AuctionService auctionService;
+    private final BlockRepository blockRepository;
 
 
     @Transactional
@@ -98,7 +100,10 @@ public class ProductService {
         List<ActivityArea> activityAreas = user.getActivityAreas();
         Point coordinate = activityAreaReader.getActivityArea(activityAreas); // 이상 사용자 활동지역 좌표
 
-        List<ProductEntity> products = productRepository.findProductsByCursor(coordinate, cursor.cursor(), cursor.size()); // 거리별 + 커서별 productEntity list조회
+        List<Long> blockUserIds = blockRepository.findByUser(user)
+                .stream().map(b -> b.getBlockedUser().getId()).toList();
+
+        List<ProductEntity> products = productRepository.findProductsByCursor(blockUserIds, coordinate, cursor.cursor(), cursor.size()); // 거리별 + 커서별 productEntity list조회
 
         Long nextCursor = products.isEmpty() ? null : products.get(products.size() - 1).getId(); // 조회된 마지막 물품의 id값 저장
 

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/CommentInfo.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/CommentInfo.java
@@ -1,0 +1,42 @@
+package org.j1p5.domain.comment;
+
+import org.j1p5.domain.comment.entity.CommentEntity;
+import org.j1p5.domain.comment.entity.CommentStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record CommentInfo(
+        String userNickname,
+        String userProfileImage,
+        Long commentId,
+        String content,
+        boolean isBlocked,//차단된 댓글인지
+        boolean isSeller,//판매자인지
+        boolean isUpdatable,//수정된 글인지
+        LocalDateTime createdAt,
+        List<CommentInfo> replies,
+        CommentStatus status
+) {
+    public static CommentInfo of(CommentEntity commentEntity, List<Long> blockUserIds, Long sellerId) {
+        boolean isSeller = commentEntity.getProduct().getUser().getId().equals(sellerId);
+        boolean isUpdated = commentEntity.getStatus().equals(CommentStatus.UPDATED);//수정여부 판단하기 위해
+        boolean isBlocked = blockUserIds.contains(commentEntity.getUser().getId());
+
+        return new CommentInfo(
+                commentEntity.getUser().getNickname(),
+                commentEntity.getUser().getImageUrl(),
+                commentEntity.getId(),
+                commentEntity.getContent(),
+                isBlocked,
+                isSeller,
+                isUpdated,
+                commentEntity.getCreatedAt(),
+                commentEntity.getReplies().stream()
+                        .map(c -> CommentInfo.of(c, blockUserIds, sellerId))
+                        .collect(Collectors.toList()),
+                commentEntity.getStatus()
+        );
+    }
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustom.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustom.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface CommentRepositoryCustom {
-    List<CommentEntity> findParentCommentByProductId(Long productId, Pageable pageable);
+    List<CommentEntity> findParentCommentByProductId(List<Long> blockUserIds, Long productId, Pageable pageable);
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustom.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustom.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface CommentRepositoryCustom {
-    List<CommentEntity> findParentCommentByProductId(List<Long> blockUserIds, Long productId, Pageable pageable);
+    List<CommentEntity> findParentCommentByProductId(Long productId, Pageable pageable);
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustomImpl.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package org.j1p5.domain.comment.repository.querydsl;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.j1p5.domain.comment.entity.CommentEntity;
 import org.j1p5.domain.comment.entity.QCommentEntity;
+import org.j1p5.domain.user.entity.QUserEntity;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -16,11 +17,13 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
 
 
     @Override
-    public List<CommentEntity> findParentCommentByProductId(Long productId, Pageable pageable) {
+    public List<CommentEntity> findParentCommentByProductId(List<Long> blockUserIds, Long productId, Pageable pageable) {
         QCommentEntity comment = QCommentEntity.commentEntity;
+        QUserEntity user = QUserEntity.userEntity;
         return jpaQueryFactory.selectFrom(comment)
                 //.leftJoin(comment.replies).fetchJoin()
-                .where(comment.product.id.eq(productId) //q객체명, 자바 변수명(!= 컬럼명)
+                .where(user.id.notIn(blockUserIds)
+                        .and(comment.product.id.eq(productId)) //q객체명, 자바 변수명(!= 컬럼명)
                         .and(comment.parentComment.isNull()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustomImpl.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/querydsl/CommentRepositoryCustomImpl.java
@@ -17,17 +17,15 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
 
 
     @Override
-    public List<CommentEntity> findParentCommentByProductId(List<Long> blockUserIds, Long productId, Pageable pageable) {
+    public List<CommentEntity> findParentCommentByProductId(Long productId, Pageable pageable) {
         QCommentEntity comment = QCommentEntity.commentEntity;
-        QUserEntity user = QUserEntity.userEntity;
+
         return jpaQueryFactory.selectFrom(comment)
                 //.leftJoin(comment.replies).fetchJoin()
-                .where(user.id.notIn(blockUserIds)
-                        .and(comment.product.id.eq(productId)) //q객체명, 자바 변수명(!= 컬럼명)
+                .where(comment.product.id.eq(productId) //q객체명, 자바 변수명(!= 컬럼명)
                         .and(comment.parentComment.isNull()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-
     }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustom.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustom.java
@@ -7,7 +7,7 @@ import org.locationtech.jts.geom.Point;
 
 public interface ProductRepositoryCustom {
 
-    List<ProductEntity> findProductsByCursor(Point coordinate, Long cursor, Integer size);
+    List<ProductEntity> findProductsByCursor(List<Long> blockUserIds, Point coordinate, Long cursor, Integer size);
 
     List<ProductEntity> findCompletedProductsByCursor(Point coordinate, Long cursor, Integer size);
 

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
@@ -11,6 +11,7 @@ import org.j1p5.domain.product.entity.ProductCategory;
 import org.j1p5.domain.product.entity.ProductEntity;
 import org.j1p5.domain.product.entity.ProductStatus;
 import org.j1p5.domain.product.entity.QProductEntity;
+import org.j1p5.domain.user.entity.QUserEntity;
 import org.locationtech.jts.geom.Point;
 
 public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
@@ -21,15 +22,17 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
     }
 
     QProductEntity qProduct = QProductEntity.productEntity;
+    QUserEntity qUserEntity = QUserEntity.userEntity;
 
     private static final int MAX_DISTANCE = 100_000;
 
     @Override
-    public List<ProductEntity> findProductsByCursor(Point coordinate, Long cursor, Integer size) {
+    public List<ProductEntity> findProductsByCursor(List<Long> blockUserIds, Point coordinate, Long cursor, Integer size) {
         // QueryDSL을 사용한 커서 기반 조회
         return queryFactory
                 .selectFrom(qProduct)
                 .where(
+                        qUserEntity.id.notIn(blockUserIds),
                         withinDistance(coordinate, MAX_DISTANCE), // 거리 조건 (100km 이내)
                         cursorCondition(cursor), // 커서 조건
                         isNotDeleted())


### PR DESCRIPTION
## 📌 관련 이슈
#126 
<br/>

## 💭 작업 내용
- 댓글, 게시글 조회 시 차단된 유저에 대한 필터링 적용
<br/>

## 🤔 참고 사항
- 입찰
    - 입찰을 한 상황에서 해당 사용자를 차단한다면?
        - 판매자가 구매자를 차단할 경우
        - 구매자가 판매자를 차단할 경우
    - 해당 사용자를 차단한 상태에서 그 물품을 보여준다면?(고도화)
- 채팅
    - 채팅을 하고있는 상황에서 해당 사용자를 차단한다면?
        - 구매자가 판매자를 차단할경우
        - 판매자가 구매자를 차단할경우
        - -> 이건 신고 느낌에 해당할듯 여기서 굳이 차단? 플로우가 어색.
- 댓글
    - 사용자를 차단했을 때 댓글은 어떻게 업데이트되어야?
- 알림(누구누구 차단했습니다)
    - 고도화
- 상품
    - 사용자를 차단했을 때 상품은 어떻게 조회되어야 하는가

**위 부분들에 대해 논의되어야할 것 같습니다!**
<br/>

## 📸 스크린샷(선택)
<br/>

## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
