### PR TITLE
[Feat] 회원탈퇴 기능 구현

### DIFF
--- a/meerket/meerket-application/src/main/java/org/j1p5/api/activityArea/service/ActivityAreaService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/activityArea/service/ActivityAreaService.java
@@ -1,6 +1,5 @@
 package org.j1p5.api.activityArea.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.j1p5.api.activityArea.exception.ActivityAreaAlreadyExistException;
 import org.j1p5.api.activityArea.exception.ActivityAreaNotFoundException;
@@ -23,6 +22,7 @@ import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -125,5 +125,17 @@ public class ActivityAreaService {
 
         return activityAreaRepository.getActivityEmdAreaByUserId(userId)
                 .orElseThrow(() -> new ActivityAreaNotFoundException(ACTIVITY_AREA_NOT_FOUND));
+    }
+
+    @Transactional
+    public void withdraw(UserEntity user) {
+        ActivityArea activityArea = activityAreaRepository.findByUser(user)
+                        .orElse(null);
+
+        if (activityArea == null) {
+            return;
+        }
+
+        activityArea.withdraw();
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/areaAuth/service/AreaAuthService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/areaAuth/service/AreaAuthService.java
@@ -72,4 +72,15 @@ public class AreaAuthService {
 
         areaAuthRepository.save(areaAuth);
     }
+
+    public void withdraw(UserEntity user) {
+        AreaAuthEntity areaAuth = areaAuthRepository.findByUser(user)
+                        .orElse(null);
+
+        if (areaAuth == null) {
+            return;
+        }
+
+        areaAuth.withdraw();
+    }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/AuctionService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/AuctionService.java
@@ -15,6 +15,7 @@ import org.j1p5.domain.product.repository.ProductRepository;
 import org.j1p5.domain.user.entity.UserEntity;
 import org.j1p5.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -165,14 +166,20 @@ public class AuctionService {
         auctionEntity.updateStatus(AuctionStatus.AWARDED);
     }
 
-
-
-
-
     private ProductEntity getProductEntity(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new WebException(ProductException.PRODUCT_NOT_FOUND));
     }
 
+    @Transactional
+    public void withdraw(UserEntity user) {
+        List<AuctionEntity> auctions = auctionRepository.findByUser(user);
+
+        if (auctions.isEmpty()) {
+            return;
+        }
+
+        auctions.forEach(AuctionEntity::withdraw);
+    }
 
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/block/service/BlockDeleteService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/block/service/BlockDeleteService.java
@@ -2,10 +2,14 @@ package org.j1p5.api.block.service;
 
 import lombok.RequiredArgsConstructor;
 import org.j1p5.api.block.validator.BlockValidator;
+import org.j1p5.domain.block.entity.BlockEntity;
 import org.j1p5.domain.block.repository.BlockRepository;
 import org.j1p5.domain.user.entity.UserEntity;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +24,16 @@ public class BlockDeleteService {
         UserEntity blockedUser = blockValidator.validateUser(unblockId);
 
         blockRepository.deleteByUserAndBlockedUser(user, blockedUser);
+    }
+
+    @Transactional
+    public void withdraw(UserEntity user) {
+        List<BlockEntity> blocks = blockRepository.findByUser(user);
+
+        if (blocks.isEmpty()) {
+            return;
+        }
+
+        blocks.forEach(BlockEntity::withdraw);
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/comment/dto/response/CommentReadResponseDto.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/comment/dto/response/CommentReadResponseDto.java
@@ -14,6 +14,7 @@ public record CommentReadResponseDto(
         CommentMemeberDto commentMemeberDto,
         Long commentId,
         String content,
+        boolean isWithdrawUser,
         boolean isBlocked,
         boolean isSeller,//판매자인지
         boolean isUpdatable,//수정된 글인지
@@ -30,6 +31,7 @@ public record CommentReadResponseDto(
                 ),
                 commentInfo.commentId(),
                 commentInfo.content(),
+                commentInfo.isWithdrawUser(),
                 commentInfo.isBlocked(),
                 commentInfo.isSeller(),
                 commentInfo.isUpdatable(),

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/comment/service/CommentService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/comment/service/CommentService.java
@@ -15,6 +15,7 @@ import org.j1p5.domain.user.entity.UserEntity;
 import org.j1p5.domain.user.service.UserReader;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -104,5 +105,15 @@ public class CommentService {
         comment.updateStatusDelete();
     }
 
+    @Transactional
+    public void withdraw(UserEntity user) {
+        List<CommentEntity> comments = commentRepository.findByUser(user);
+
+        if (comments.isEmpty()) {
+            return;
+        }
+
+        comments.forEach(CommentEntity::updateStatusDelete);
+    }
 
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductImageService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductImageService.java
@@ -1,4 +1,28 @@
 package org.j1p5.api.product.service;
 
+import lombok.RequiredArgsConstructor;
+import org.j1p5.domain.image.entitiy.ImageEntity;
+import org.j1p5.domain.image.repository.ImageRepository;
+import org.j1p5.domain.product.entity.ProductEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class ProductImageService {
+
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public void withdraw(ProductEntity product) {
+        List<ImageEntity> images = imageRepository.findByProduct(product);
+
+        if (images.isEmpty()) {
+            return;
+        }
+
+        images.forEach(ImageEntity::withdraw);
+    }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductImageService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductImageService.java
@@ -1,0 +1,4 @@
+package org.j1p5.api.product.service;
+
+public class ProductImageService {
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
@@ -1,6 +1,5 @@
 package org.j1p5.api.product.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.j1p5.api.auction.quartz.QuartzService;
@@ -29,6 +28,7 @@ import org.j1p5.domain.user.repository.UserRepository;
 import org.j1p5.infrastructure.global.exception.InfraException;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
 import java.time.Duration;
@@ -49,6 +49,7 @@ public class ProductService {
     private final ProductUserReader userReader;
     private final ProductAppender productAppender;
     private final ImageService imageService;
+    private final ProductImageService productImageService;
     private final RegionAuthHandler userRegionauth;
     private final ActivityAreaReader activityAreaReader;
     private final ProductRepository productRepository;
@@ -332,6 +333,17 @@ public class ProductService {
         productEntity.updateStatusToComplete();
     }
 
+    @Transactional
+    public void withdraw(UserEntity user) {
+        List<ProductEntity> products = productRepository.findByUser(user);
 
+        if (products.isEmpty()) {
+            return;
+        }
 
+        products.forEach(p -> {
+            productImageService.withdraw(p);
+            p.withdraw();
+        });
+    }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/service/ProductService.java
@@ -152,7 +152,7 @@ public class ProductService {
         ProductEntity product = productRepository.findById(productId)
                 .orElseThrow(() -> new DomainException(PRODUCT_NOT_FOUND));
         UserEntity user = userReader.getUser(userId);
-        if (product.getStatus().equals(ProductStatus.DELETED)) {
+        if (product.getStatus().equals(ProductStatus.DELETED) || product.isDeleted()) {
             throw new DomainException(PRODUCT_IS_DELETED);
         }
 

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/report/service/ReportService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/report/service/ReportService.java
@@ -1,0 +1,29 @@
+package org.j1p5.api.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.j1p5.domain.comment.entity.CommentEntity;
+import org.j1p5.domain.report.entity.ReportEntity;
+import org.j1p5.domain.report.repository.ReportRepository;
+import org.j1p5.domain.user.entity.UserEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+
+    @Transactional
+    public void withdraw(UserEntity user) {
+        List<ReportEntity> reports = reportRepository.findByUser(user);
+
+        if (reports.isEmpty()) {
+            return;
+        }
+
+        reports.forEach(ReportEntity::withdraw);
+    }
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/controller/UserController.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/controller/UserController.java
@@ -15,6 +15,7 @@ import org.j1p5.api.user.dto.request.ProfileSettingRequest;
 import org.j1p5.api.user.dto.response.ProfileResponse;
 import org.j1p5.api.user.usecase.UserProfileReadUsecase;
 import org.j1p5.api.user.usecase.UserProfileSettingUsecase;
+import org.j1p5.api.user.usecase.UserWithdrawUsecase;
 import org.j1p5.common.exception.ErrorResponse;
 import org.j1p5.domain.user.UserProfile;
 import org.springframework.context.annotation.Profile;
@@ -29,6 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserController {
     private final UserProfileSettingUsecase userProfileSettingUsecase;
     private final UserProfileReadUsecase userProfileReadUsecase;
+    private final UserWithdrawUsecase userWithdrawUsecase;
 
     @GetMapping("/profile")
     @Operation(summary = "유저 프로필 조회", description = "유저 프로필 조회 API")
@@ -74,5 +76,12 @@ public class UserController {
     public Response<UserProfile> getUserInfo(@LoginUser Long userId) {
         UserProfile userProfile = userProfileReadUsecase.getSessionInfo(userId);
         return Response.onSuccess(userProfile);
+    }
+
+    @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴 API")
+    @GetMapping("/withdraw")
+    public Response<Void> withdraw(@LoginUser Long userId) {
+        userWithdrawUsecase.execute(userId);
+        return Response.onSuccess();
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/controller/UserController.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/controller/UserController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.j1p5.api.global.annotation.LoginUser;
@@ -80,8 +81,13 @@ public class UserController {
 
     @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴 API")
     @GetMapping("/withdraw")
-    public Response<Void> withdraw(@LoginUser Long userId) {
+    public Response<Void> withdraw(
+            @LoginUser Long userId,
+            HttpServletRequest request
+    ) {
         userWithdrawUsecase.execute(userId);
+        request.getSession().invalidate();
+
         return Response.onSuccess();
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/service/UserWithdrawService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/service/UserWithdrawService.java
@@ -1,0 +1,4 @@
+package org.j1p5.api.user.service;
+
+public class UserWithdrawService {
+}

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/service/UserWithdrawService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/service/UserWithdrawService.java
@@ -1,4 +1,20 @@
 package org.j1p5.api.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.j1p5.domain.user.entity.UserEntity;
+import org.j1p5.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class UserWithdrawService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void withdraw(UserEntity user) {
+        user.withdraw();
+        userRepository.save(user);
+    }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/usecase/UserWithdrawUsecase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/usecase/UserWithdrawUsecase.java
@@ -7,6 +7,7 @@ import org.j1p5.api.auction.service.AuctionService;
 import org.j1p5.api.block.service.BlockDeleteService;
 import org.j1p5.api.comment.service.CommentService;
 import org.j1p5.api.product.service.ProductService;
+import org.j1p5.api.report.service.ReportService;
 import org.j1p5.api.user.exception.UserNotFoundException;
 import org.j1p5.api.user.service.UserWithdrawService;
 import org.j1p5.domain.user.entity.UserEntity;
@@ -27,6 +28,7 @@ public class UserWithdrawUsecase {
     private final ProductService productService;
     private final BlockDeleteService blockDeleteService;
     private final UserWithdrawService userWithdrawService;
+    private final ReportService reportService;
 
     public void execute(Long userId) {
         UserEntity user = userRepository.findById(userId)
@@ -38,8 +40,8 @@ public class UserWithdrawUsecase {
         auctionService.withdraw(user);
         productService.withdraw(user);
         blockDeleteService.withdraw(user);
-        //TODO : report delete 처리
-        userWithdrawService.withdraw(user);
+        reportService.withdraw(user);
 
+        userWithdrawService.withdraw(user);
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/usecase/UserWithdrawUsecase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/usecase/UserWithdrawUsecase.java
@@ -1,4 +1,45 @@
 package org.j1p5.api.user.usecase;
 
+import lombok.RequiredArgsConstructor;
+import org.j1p5.api.activityArea.service.ActivityAreaService;
+import org.j1p5.api.areaAuth.service.AreaAuthService;
+import org.j1p5.api.auction.service.AuctionService;
+import org.j1p5.api.block.service.BlockDeleteService;
+import org.j1p5.api.comment.service.CommentService;
+import org.j1p5.api.product.service.ProductService;
+import org.j1p5.api.user.exception.UserNotFoundException;
+import org.j1p5.api.user.service.UserWithdrawService;
+import org.j1p5.domain.user.entity.UserEntity;
+import org.j1p5.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import static org.j1p5.api.global.excpetion.WebErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
 public class UserWithdrawUsecase {
+
+    private final UserRepository userRepository;
+    private final ActivityAreaService activityAreaService;
+    private final AreaAuthService areaAuthService;
+    private final CommentService commentService;
+    private final AuctionService auctionService;
+    private final ProductService productService;
+    private final BlockDeleteService blockDeleteService;
+    private final UserWithdrawService userWithdrawService;
+
+    public void execute(Long userId) {
+        UserEntity user = userRepository.findById(userId)
+                        .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+        activityAreaService.withdraw(user);
+        areaAuthService.withdraw(user);
+        commentService.withdraw(user);
+        auctionService.withdraw(user);
+        productService.withdraw(user);
+        blockDeleteService.withdraw(user);
+        //TODO : report delete 처리
+        userWithdrawService.withdraw(user);
+
+    }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/user/usecase/UserWithdrawUsecase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/user/usecase/UserWithdrawUsecase.java
@@ -1,0 +1,4 @@
+package org.j1p5.api.user.usecase;
+
+public class UserWithdrawUsecase {
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/activityArea/entity/ActivityArea.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/activityArea/entity/ActivityArea.java
@@ -41,4 +41,8 @@ public class ActivityArea {
     public void updateEmdArea(EmdArea emdArea) {
         this.emdArea = emdArea;
     }
+
+    public void withdraw() {
+        this.isDeleted = true;
+    }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/activityArea/entity/ActivityArea.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/activityArea/entity/ActivityArea.java
@@ -26,6 +26,9 @@ public class ActivityArea {
     @JoinColumn(name = "emd_id")
     private EmdArea emdArea;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     private ActivityArea(UserEntity user, EmdArea emdArea) {
         this.user = user;
         this.emdArea = emdArea;

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/areaAuth/entity/AreaAuthEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/areaAuth/entity/AreaAuthEntity.java
@@ -48,5 +48,7 @@ public class AreaAuthEntity {
         this.emdArea = emdArea;
     }
 
-
+    public void withdraw() {
+        this.isDeleted = true;
+    }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/areaAuth/entity/AreaAuthEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/areaAuth/entity/AreaAuthEntity.java
@@ -27,6 +27,9 @@ public class AreaAuthEntity {
     @JoinColumn(name = "emd_id")
     private EmdArea emdArea;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     private AreaAuthEntity(LocalDateTime timeStamp, UserEntity user, EmdArea emdArea) {
         this.timeStamp = timeStamp;
         this.user = user;

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/entity/AuctionEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/entity/AuctionEntity.java
@@ -57,5 +57,7 @@ public class AuctionEntity extends BaseEntity {
         this.status = status;
     }
 
-
+    public void withdraw() {
+        this.isDeleted = true;
+    }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/entity/AuctionEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/entity/AuctionEntity.java
@@ -35,6 +35,8 @@ public class AuctionEntity extends BaseEntity {
     @Column(name = "auction_status", nullable = false)
     private AuctionStatus status;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
 
     private AuctionEntity(UserEntity user, ProductEntity product, int price) {
         this.product = product;

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/repository/AuctionRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/repository/AuctionRepository.java
@@ -1,6 +1,7 @@
 package org.j1p5.domain.auction.repository;
 
 import org.j1p5.domain.auction.entity.AuctionEntity;
+import org.j1p5.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -78,6 +79,8 @@ public interface AuctionRepository extends JpaRepository<AuctionEntity, Long> {
             @Param("productId") Long productId,
             @Param("userId") Long userId
     );
+
+    List<AuctionEntity> findByUser(UserEntity user);
 
 
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/repository/AuctionRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/auction/repository/AuctionRepository.java
@@ -15,7 +15,8 @@ public interface AuctionRepository extends JpaRepository<AuctionEntity, Long> {
                 select a
                 from auction a
                 join a.product p
-                where a.user.id = :userId
+                where a.isDelete = false
+                and a.user.id = :userId
                 and p.status = org.j1p5.domain.product.entity.ProductStatus.BIDDING
                 and a.status = org.j1p5.domain.auction.entity.AuctionStatus.BIDDING
             """)

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/block/entity/BlockEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/block/entity/BlockEntity.java
@@ -36,4 +36,8 @@ public class BlockEntity extends BaseEntity {
     public static BlockEntity create(UserEntity blockedUser, UserEntity user) {
         return new BlockEntity(blockedUser, user);
     }
+
+    public void withdraw() {
+        this.isDeleted = true;
+    }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/block/entity/BlockEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/block/entity/BlockEntity.java
@@ -25,6 +25,9 @@ public class BlockEntity extends BaseEntity {
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     private BlockEntity(UserEntity blockedUser, UserEntity user) {
         this.blockedUser = blockedUser;
         this.user = user;

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/CommentInfo.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/CommentInfo.java
@@ -13,6 +13,7 @@ public record CommentInfo(
         String userProfileImage,
         Long commentId,
         String content,
+        boolean isWithdrawUser, //탈퇴한 사용자인지
         boolean isBlocked,//차단된 댓글인지
         boolean isSeller,//판매자인지
         boolean isUpdatable,//수정된 글인지
@@ -24,6 +25,7 @@ public record CommentInfo(
         boolean isSeller = commentEntity.getProduct().getUser().getId().equals(sellerId);
         boolean isUpdated = commentEntity.getStatus().equals(CommentStatus.UPDATED);//수정여부 판단하기 위해
         boolean isBlocked = blockUserIds.contains(commentEntity.getUser().getId());
+        boolean isWithdrawUser = commentEntity.getUser().isDeleted();
 
         return new CommentInfo(
                 commentEntity.getUser().getId(),
@@ -31,6 +33,7 @@ public record CommentInfo(
                 commentEntity.getUser().getImageUrl(),
                 commentEntity.getId(),
                 commentEntity.getContent(),
+                isWithdrawUser,
                 isBlocked,
                 isSeller,
                 isUpdated,

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/CommentRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/comment/repository/CommentRepository.java
@@ -2,7 +2,11 @@ package org.j1p5.domain.comment.repository;
 
 import org.j1p5.domain.comment.entity.CommentEntity;
 import org.j1p5.domain.comment.repository.querydsl.CommentRepositoryCustom;
+import org.j1p5.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<CommentEntity, Long>, CommentRepositoryCustom {
+    List<CommentEntity> findByUser(UserEntity user);
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/history/search/entity/SearchHistory.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/history/search/entity/SearchHistory.java
@@ -21,6 +21,9 @@ public class SearchHistory {
     @Column(name = "timestamp", nullable = false)
     private LocalDateTime searchDatetime;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity user;

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/image/entitiy/ImageEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/image/entitiy/ImageEntity.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.j1p5.domain.global.entity.BaseEntity;
+import org.j1p5.domain.product.entity.ProductEntity;
 
 @Entity(name = "image")
 @Getter
@@ -23,7 +24,15 @@ public class ImageEntity extends BaseEntity {
     @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean isDeleted;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private ProductEntity product;
+
     public static ImageEntity from(String imageUrl) {
-        return new ImageEntity(null, imageUrl, false);
+        return new ImageEntity(null, imageUrl, false, null);
+    }
+
+    public void withdraw() {
+        this.isDeleted = true;
     }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/image/entitiy/ImageEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/image/entitiy/ImageEntity.java
@@ -20,7 +20,10 @@ public class ImageEntity extends BaseEntity {
     @Column(name = "image_url", nullable = false, length = 2048)
     private String imageUrl;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     public static ImageEntity from(String imageUrl) {
-        return new ImageEntity(null, imageUrl);
+        return new ImageEntity(null, imageUrl, false);
     }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/image/repository/ImageRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/image/repository/ImageRepository.java
@@ -1,6 +1,11 @@
 package org.j1p5.domain.image.repository;
 
 import org.j1p5.domain.image.entitiy.ImageEntity;
+import org.j1p5.domain.product.entity.ProductEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ImageRepository extends JpaRepository<ImageEntity, Long> {}
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
+    List<ImageEntity> findByProduct(ProductEntity product);
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/entity/ProductEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/entity/ProductEntity.java
@@ -77,6 +77,9 @@ public class ProductEntity extends BaseEntity {
     @Column(name = "winning_price")
     private Integer winningPrice;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     public void addImage(ImageEntity image) {
         imageEntityList.add(image);
     }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/entity/ProductEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/entity/ProductEntity.java
@@ -147,5 +147,9 @@ public class ProductEntity extends BaseEntity {
         this.status = ProductStatus.COMPLETED;
     }
 
+    public void withdraw() {
+        this.isDeleted = true;
+    }
+
 
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/ProductRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/ProductRepository.java
@@ -2,7 +2,12 @@ package org.j1p5.domain.product.repository;
 
 import org.j1p5.domain.product.entity.ProductEntity;
 import org.j1p5.domain.product.repository.querydsl.ProductRepositoryCustom;
+import org.j1p5.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductRepository
-        extends JpaRepository<ProductEntity, Long>, ProductRepositoryCustom {}
+        extends JpaRepository<ProductEntity, Long>, ProductRepositoryCustom {
+    List<ProductEntity> findByUser(UserEntity user);
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
@@ -35,7 +35,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         qUserEntity.id.notIn(blockUserIds),
                         withinDistance(coordinate, MAX_DISTANCE), // 거리 조건 (100km 이내)
                         cursorCondition(cursor), // 커서 조건
-                        isNotDeleted())
+                        isNotDeleted(),
+                        isNotWithdrawalUser())
                 .orderBy(qProduct.id.desc()) // 내림차순 정렬
                 .limit(size) // 페이지 크기 제한
                 .fetch();
@@ -50,6 +51,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         withinDistance(coordinate, MAX_DISTANCE),
                         cursorCondition(cursor),
                         isNotDeleted(),
+                        isNotWithdrawalUser(),
                         qProduct.status.eq(ProductStatus.COMPLETED)
                 )
                 .orderBy(qProduct.id.desc())
@@ -64,6 +66,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         withinDistance(coordinate, MAX_DISTANCE),
                         cursorCondition(cursor),
                         isNotDeleted(),
+                        isNotWithdrawalUser(),
                         findCategory(category)
                 )
                 .orderBy(qProduct.id.desc())
@@ -153,5 +156,9 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
             return null;
         }
         return qProduct.title.like("%" +keyword + "%");
+    }
+
+    private BooleanExpression isNotWithdrawalUser() {
+        return qProduct.isDeleted.eq(false);
     }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/report/entity/ReportEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/report/entity/ReportEntity.java
@@ -43,4 +43,8 @@ public class ReportEntity extends BaseEntity {
     public static ReportEntity create(ReportType reportType, Long targetId, String content, UserEntity user) {
         return new ReportEntity(reportType, targetId, content, user);
     }
+
+    public void withdraw() {
+        this.isDeleted = true;
+    }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/report/entity/ReportEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/report/entity/ReportEntity.java
@@ -26,6 +26,9 @@ public class ReportEntity extends BaseEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity user;

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/report/repository/ReportRepository.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/report/repository/ReportRepository.java
@@ -1,6 +1,11 @@
 package org.j1p5.domain.report.repository;
 
 import org.j1p5.domain.report.entity.ReportEntity;
+import org.j1p5.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReportRepository extends JpaRepository<ReportEntity, Long> {}
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
+    List<ReportEntity> findByUser(UserEntity user);
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/UserEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/UserEntity.java
@@ -33,6 +33,9 @@ public class UserEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isDeleted;
+
     @OneToMany(mappedBy = "user")
     private List<ActivityArea> activityAreas = new ArrayList<>();
 

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/UserEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/UserEntity.java
@@ -57,4 +57,8 @@ public class UserEntity extends BaseEntity {
     public void updateProfile(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void withdraw() {
+        this.isDeleted = true;
+    }
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/UserEntity.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/user/entity/UserEntity.java
@@ -16,7 +16,7 @@ public class UserEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "social_id", nullable = false, length = 50)
+    @Column(name = "social_id", length = 50)
     private String socialId;
 
     @Column(name = "provider", nullable = false, length = 10)
@@ -60,5 +60,6 @@ public class UserEntity extends BaseEntity {
 
     public void withdraw() {
         this.isDeleted = true;
+        this.socialId = null;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
#140 
<br/>

## 💭 작업 내용
- 회원 탈퇴 기능 구현
- 회원 탈퇴한 사용자 정보 조회 필터링
<br/>

## 🤔 참고 사항
<h3>회원탈퇴 로직에 대해 의견 부탁드립니다!</h3>
회원 탈퇴 로직<br>

- 관련 도메인에 한해 단순하게 soft delete실행
- Soft delete이후 타인이 탈퇴한 유저가 올린 상품, 댓글 등 정보 조회하고자 할 때 필터링되어서 조회가 되어야 함.
- 재가입 시 기존 데이터 없이 새로운 row에 저장될 예정입니다.
<br/>

## 📸 스크린샷(선택)
<br/>

## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
