### PR TITLE
[Hotfix] 상품 조회 시 차단 유저 null 에러 픽스

### DIFF
--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/product/repository/querydsl/ProductRepositoryCustomImpl.java
@@ -32,7 +32,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
         return queryFactory
                 .selectFrom(qProduct)
                 .where(
-                        qUserEntity.id.notIn(blockUserIds),
+                        blockNotInCondition(blockUserIds),
                         withinDistance(coordinate, MAX_DISTANCE), // 거리 조건 (100km 이내)
                         cursorCondition(cursor), // 커서 조건
                         isNotDeleted(),
@@ -129,6 +129,14 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
             return null; // 커서가 없으면 조건 생략
         }
         return qProduct.id.lt(cursor);
+    }
+
+    private BooleanExpression blockNotInCondition(List<Long> blockUserIds) {
+        if (blockUserIds == null || blockUserIds.isEmpty()) {
+            return null;
+        }
+
+        return qUserEntity.id.notIn(blockUserIds);
     }
 
     private BooleanExpression isNotDeleted() {


### PR DESCRIPTION
## 📌 관련 이슈
#147 
<br/>

## 💭 작업 내용
- 상품 조회 시 차단 유저가 없을 때 에러 발생 픽스
<br/>

## 🤔 참고 사항
<!-- 참고 사항을 설명해주세요 -->
<br/>

## 📸 스크린샷(선택)
<br/>

## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
