### PR TITLE
Feat/#155 auction domain refactor and concurrency

### DIFF
--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/exception/AuctionException.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/exception/AuctionException.java
@@ -11,18 +11,12 @@ public enum AuctionException implements BaseErrorCode {
     BID_USER_NOT_AUTHORIZED(403, "BID_USER_403", "해당 입찰에 대한 권한이 없습니다."),
     BID_AMOUNT_TOO_LOW(400, "BID_AMOUNT_400", "입찰 금액이 기존 입찰 금액보다 낮습니다."),
     DUPLICATE_BID(400, "DUPLICATE_BID", "이미 입찰한 기록이 있습니다."),
-    SELLER_CANNOT_CREATE_BID(500,"SELLER_BID_500","판매자는 판매글에 입찰을 할 수 없습니다.")
-
+    SELLER_CANNOT_CREATE_BID(500, "SELLER_BID_500", "판매자는 판매글에 입찰을 할 수 없습니다."),
+    DUPLICATE_BID_REQUEST(400, "DUPLICATE_BID_REQUEST", "중복된 입찰 요청입니다."),
+    DUPLICATE_BID_UPDATE_REQUEST(400, "DUPLICATE_BID_UPDATE_REQUEST", "중복된 입찰 수정 요청입니다."),
+    AUCTION_EDIT_IN_PROGRESS(403, "AUCTION_EDIT_IN_PROGRESS", "판매자가 게시글을 수정 중이어서 입찰이 불가능합니다."),
     ;
-
-
-
-
-
-
     ;
-
-
 
     private final int status;
     private final String errorCode;
@@ -33,7 +27,6 @@ public enum AuctionException implements BaseErrorCode {
         this.errorCode = errorCode;
         this.message = message;
     }
-
 
     @Override
     public ErrorResponse getErrorResponse() {

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/quartz/QuartzService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/quartz/QuartzService.java
@@ -1,5 +1,8 @@
 package org.j1p5.api.auction.quartz;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.j1p5.api.auction.job.AuctionClosingJob;
 import org.j1p5.domain.product.entity.ProductEntity;
@@ -7,21 +10,14 @@ import org.quartz.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
-
 @Slf4j
 @Service
 public class QuartzService {
 
-    @Autowired
-    private Scheduler scheduler;
-
+    @Autowired private Scheduler scheduler;
 
     // 물품 등록시 job 등록
     public void scheduleAuctionClosingJob(ProductEntity product) {
-        log.info("product잘들어옴?{}", product);
 
         JobDetail jobDetail = JobBuilder.newJob(AuctionClosingJob.class)
                 .withIdentity("auctionJob_" + product.getId(), "auctionGroup")
@@ -38,12 +34,11 @@ public class QuartzService {
 
         try {
             scheduler.scheduleJob(jobDetail, trigger);
-            log.info("작업 완료");
+            log.info("Job 등록 작업 완료");
         } catch (SchedulerException e) {
-            log.error("스케줄 등록 과정 중 에러 발생 ",e);
+            log.error("스케줄 등록 과정 중 에러 발생 ", e);
         }
     }
-
 
     // 물품 마감 시간이 변경되었을 때 job 수정
     public void rescheduleAuctionClosing(Long productId, LocalDateTime newExpiredTime) {
@@ -56,13 +51,12 @@ public class QuartzService {
 
         try {
             scheduler.rescheduleJob(triggerKey, newTrigger);
-            log.info("경매 마감 시간을 재설정. productId = {}",productId);
+            log.info("경매 마감 시간을 재설정. productId = {}", productId);
             log.info("수정된 경매 마감 시간은. newExpiredTime = {}", newExpiredTime);
         } catch (SchedulerException e) {
-            log.error("스케줄 재설정 과정 중 에러 발생",e);
+            log.error("스케줄 재설정 과정 중 에러 발생", e);
         }
     }
-
 
     // 물품 제거시 job 삭제
     public void cancelAuctionJob(Long productId) {
@@ -78,6 +72,4 @@ public class QuartzService {
             log.error("job 삭제 중 에러 발생", e);
         }
     }
-
-
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/AuctionService.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/AuctionService.java
@@ -2,7 +2,6 @@ package org.j1p5.api.auction.service;
 
 import lombok.RequiredArgsConstructor;
 import org.j1p5.api.auction.dto.response.BidHistoryResponse;
-import org.j1p5.api.auction.dto.response.PlaceBidResponse;
 import org.j1p5.api.auction.exception.AuctionException;
 import org.j1p5.api.global.excpetion.WebException;
 import org.j1p5.api.product.exception.ProductException;
@@ -18,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -26,34 +26,6 @@ public class AuctionService {
     private final AuctionRepository auctionRepository;
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
-
-    // 현재 사용자가 해당 상품에 이미 입찰한 기록이 없는지 확인
-    public void checkDuplicateBid(Long userId, Long productId) {
-        boolean exists = auctionRepository.existsByUserIdAndProductId(userId, productId);
-        if (exists) {
-            throw new WebException(AuctionException.DUPLICATE_BID);
-        }
-    }
-
-
-    // 입찰하기
-    public PlaceBidResponse placeBid(Long userId, Long productId, int price) {
-
-        ProductEntity productEntity = getProductEntity(productId);
-
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new WebException(AuctionException.BID_USER_NOT_FOUND));
-
-        if (productEntity.getMinPrice() > price) {
-            throw new WebException(AuctionException.AUCTION_MIN_PRICE_ERROR);
-        }
-
-        AuctionEntity auctionEntity = AuctionEntity.create(userEntity, productEntity, price);
-
-        auctionRepository.save(auctionEntity);
-
-        return PlaceBidResponse.fromEntity(auctionEntity);
-    }
 
 
     // 해당 입찰이 실제 해당 유저의 입찰인지 확인
@@ -64,71 +36,16 @@ public class AuctionService {
         AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new WebException(AuctionException.BID_NOT_FOUND));
 
-        if (userEntity.getId() != auctionEntity.getUser().getId()) {
+        if (!Objects.equals(userEntity.getId(), auctionEntity.getUser().getId())) {
             throw new WebException(AuctionException.BID_USER_NOT_AUTHORIZED);
         }
     }
-
-    // 입찰 취소하기
-    public Long cancelBid(Long auctionId) {
-        AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
-                .orElseThrow(() -> new WebException(AuctionException.BID_NOT_FOUND));
-
-        auctionEntity.updateStatus(AuctionStatus.CANCELLED);
-        auctionRepository.save(auctionEntity);
-        return auctionEntity.getProduct().getId();
-    }
-
-
 
     // 현재 조기마감 상태인지 확인
     public boolean isEarlyClosure(Long productId) {
         ProductEntity productEntity = getProductEntity(productId);
 
         return productEntity.isEarly();
-    }
-
-
-    // 조기마감 상태일때의 수정
-    public AuctionEntity updateBidPriceForEarlyClosure(Long auctionId, int price) {
-        AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
-                .orElseThrow(() -> new WebException(AuctionException.BID_NOT_FOUND));
-
-        if (auctionEntity.getPrice() >= price) {
-            throw new WebException(AuctionException.BID_AMOUNT_TOO_LOW);
-        }
-
-        auctionEntity.updatePrice(price);
-        auctionRepository.save(auctionEntity);
-        return auctionEntity;
-    }
-
-
-    // 조기마감 상태가 아닐때의 수정
-    public AuctionEntity updateBidPriceWithMinimumLimit(Long auctionId, Long productId, int price) {
-        ProductEntity productEntity = getProductEntity(productId);
-
-        if (productEntity.getMinPrice() > price) {
-            throw new WebException(AuctionException.AUCTION_MIN_PRICE_ERROR);
-        }
-
-        AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
-                .orElseThrow(() -> new WebException(AuctionException.BID_NOT_FOUND));
-
-        auctionEntity.updatePrice(price);
-        auctionRepository.save(auctionEntity);
-        return auctionEntity;
-    }
-
-
-    // 입찰 중인 기록 조회
-    public List<AuctionEntity> getBiddingAuctionsByUserId(Long userId) {
-        return auctionRepository.findBiddingAuctionsByUserId(userId);
-    }
-
-    // 구매 완료 기록 조회
-    public List<AuctionEntity> getCompletedPurchasesByUserId(Long userId) {
-        return auctionRepository.findCompletedPurchasesByUserId(userId);
     }
 
 

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/CancelBidUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/CancelBidUseCase.java
@@ -1,16 +1,19 @@
 package org.j1p5.api.auction.service.usecase;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.j1p5.api.auction.exception.AuctionException;
 import org.j1p5.api.auction.service.AuctionService;
 import org.j1p5.api.fcm.FcmService;
+import org.j1p5.api.global.excpetion.WebException;
 import org.j1p5.domain.auction.entity.AuctionEntity;
+import org.j1p5.domain.auction.entity.AuctionStatus;
 import org.j1p5.domain.auction.repository.AuctionRepository;
 import org.j1p5.domain.global.exception.DomainException;
 import org.j1p5.domain.product.entity.ProductEntity;
 import org.j1p5.domain.product.repository.ProductRepository;
 import org.j1p5.infrastructure.global.exception.InfraException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -38,7 +41,7 @@ public class CancelBidUseCase {
 
         auctionService.verifyUserBidOwnership(userId, auctionId);
 
-        Long productId = auctionService.cancelBid(auctionId);
+        Long productId = cancelBid(auctionId);
 
         ProductEntity product = productRepository.findById(productId)
                 .orElseThrow(() -> new DomainException(PRODUCT_NOT_FOUND));
@@ -53,5 +56,15 @@ public class CancelBidUseCase {
         } catch (Exception e) {
             throw new InfraException(CANCEL_BID_FCM_SELLER_ERROR);
         }
+    }
+
+    // 입찰 취소하기
+    private Long cancelBid(Long auctionId) {
+        AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new WebException(AuctionException.BID_NOT_FOUND));
+
+        auctionEntity.updateStatus(AuctionStatus.CANCELLED);
+        auctionRepository.save(auctionEntity);
+        return auctionEntity.getProduct().getId();
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/GetBiddingHistoryUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/GetBiddingHistoryUseCase.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.j1p5.api.auction.dto.response.BidHistoryResponse;
 import org.j1p5.api.auction.service.AuctionService;
 import org.j1p5.domain.auction.entity.AuctionEntity;
+import org.j1p5.domain.auction.repository.AuctionRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 public class GetBiddingHistoryUseCase {
 
     private final AuctionService auctionService;
+    private final AuctionRepository auctionRepository;
 
     /**
      * 입찰 내역 조회
@@ -22,9 +24,14 @@ public class GetBiddingHistoryUseCase {
      */
     public List<BidHistoryResponse> execute(Long userId) {
 
-        List<AuctionEntity> entities = auctionService.getBiddingAuctionsByUserId(userId);
+        List<AuctionEntity> entities = getBiddingAuctionsByUserId(userId);
 
         return auctionService.getAuctionHistoryResponses(entities);
 
+    }
+
+    // 입찰 중인 기록 조회
+    private List<AuctionEntity> getBiddingAuctionsByUserId(Long userId) {
+        return auctionRepository.findBiddingAuctionsByUserId(userId);
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/GetCompletedPurchasesUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/GetCompletedPurchasesUseCase.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.j1p5.api.auction.dto.response.BidHistoryResponse;
 import org.j1p5.api.auction.service.AuctionService;
 import org.j1p5.domain.auction.entity.AuctionEntity;
+import org.j1p5.domain.auction.repository.AuctionRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 public class GetCompletedPurchasesUseCase {
 
     private final AuctionService auctionService;
+    private final AuctionRepository auctionRepository;
 
     /**
      * 거래 완료 입찰 내역 조회
@@ -22,9 +24,14 @@ public class GetCompletedPurchasesUseCase {
      */
     public List<BidHistoryResponse> execute(Long userId) {
 
-        List<AuctionEntity> entities = auctionService.getCompletedPurchasesByUserId(userId);
+        List<AuctionEntity> entities = getCompletedPurchasesByUserId(userId);
 
         return auctionService.getAuctionHistoryResponses(entities);
 
+    }
+
+    // 구매 완료 기록 조회
+    private List<AuctionEntity> getCompletedPurchasesByUserId(Long userId) {
+        return auctionRepository.findCompletedPurchasesByUserId(userId);
     }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/PlaceBidUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/PlaceBidUseCase.java
@@ -1,9 +1,13 @@
 package org.j1p5.api.auction.service.usecase;
 
+import static org.j1p5.api.auction.exception.AuctionException.SELLER_CANNOT_CREATE_BID;
+import static org.j1p5.api.product.exception.ProductException.PRODUCT_NOT_FOUND;
+import static org.j1p5.domain.global.exception.DomainErrorCode.USER_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.j1p5.api.auction.dto.response.PlaceBidResponse;
 import org.j1p5.api.auction.exception.AuctionException;
-import org.j1p5.api.auction.service.AuctionService;
 import org.j1p5.api.fcm.FcmService;
 import org.j1p5.api.global.excpetion.WebException;
 import org.j1p5.domain.auction.entity.AuctionEntity;
@@ -11,17 +15,15 @@ import org.j1p5.domain.auction.repository.AuctionRepository;
 import org.j1p5.domain.global.exception.DomainException;
 import org.j1p5.domain.product.entity.ProductEntity;
 import org.j1p5.domain.product.repository.ProductRepository;
+import org.j1p5.domain.redis.RedisBidLockService;
+import org.j1p5.domain.redis.RedisIdempotencyService;
 import org.j1p5.domain.user.entity.UserEntity;
 import org.j1p5.domain.user.repository.UserRepository;
-import org.j1p5.infrastructure.global.exception.InfraException;
+import org.j1p5.infrastructure.redis.service.RedisProductEditLockServiceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.j1p5.api.auction.exception.AuctionException.SELLER_CANNOT_CREATE_BID;
-import static org.j1p5.api.product.exception.ProductException.PRODUCT_NOT_FOUND;
-import static org.j1p5.domain.global.exception.DomainErrorCode.USER_NOT_FOUND;
-import static org.j1p5.infrastructure.fcm.exception.FcmException.CREATE_BID_FCM_ERROR;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlaceBidUseCase {
@@ -30,10 +32,16 @@ public class PlaceBidUseCase {
     private final FcmService fcmService;
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
+    private final RedisBidLockService redisBidLockService;
+    private final RedisIdempotencyService redisIdempotencyService;
+    private final RedisProductEditLockServiceImpl redisProductEditLockServiceImpl;
+
+    private static final long REQUEST_ID_TTL = 30;
+    private static final long BID_LOCK_TTL = 300;
 
     /**
-     * 입찰 후 알림 전송
-     * 판매자는 입찰 불가, 중복 입찰 불가
+     * 입찰 후 알림 전송 판매자는 입찰 불가, 중복 입찰 불가
+     *
      * @author sunghyun, yechan
      * @param userId
      * @param productId
@@ -42,40 +50,76 @@ public class PlaceBidUseCase {
      */
     @Transactional
     public PlaceBidResponse execute(Long userId, Long productId, int price) {
+        // TODO 사용자의 거리를 기반하여 물건의 위치와 얼마나 떨어져있는지 확인해야 함.
 
-        //판매자가 자기꺼 입찰하는경우 막아야함
-        ProductEntity product = productRepository.findById(productId)
-                .orElseThrow(() -> new DomainException(PRODUCT_NOT_FOUND));
-        UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new DomainException(USER_NOT_FOUND));
-
-        if(product.getUser().equals(user)){
-            throw new DomainException(SELLER_CANNOT_CREATE_BID);
+        // 멱등성 확인
+        String requestId = "product:" + productId + ":user:" + userId;
+        if (!redisIdempotencyService.saveRequestId(requestId, REQUEST_ID_TTL)) {
+            throw new WebException(AuctionException.DUPLICATE_BID_REQUEST);
         }
 
-        checkDuplicateBid(userId, productId);
+        // 상품 수정중인지 확인
+        String editLockKey = "product:" + productId + ":lock:edit";
+        if (redisProductEditLockServiceImpl.isEditLocked(editLockKey)) {
+            throw new WebException(AuctionException.AUCTION_EDIT_IN_PROGRESS);
+        }
 
-        PlaceBidResponse placeBidResponse = placeBid(userId, productId, price);
-
-        product.updateHasBuyer();
-        //productRepository.save(product);
+        // 입찰 중 락 설정
+        String bidLockKey = "product:" + productId + ":lock:bid";
 
         try {
-            fcmService.sendSellerBidMessage(productId);
-        } catch (Exception e) {
-            throw new InfraException(CREATE_BID_FCM_ERROR);
+            redisBidLockService.incrementBid(bidLockKey, BID_LOCK_TTL);
+
+            ProductEntity product = getProductEntity(productId);
+            UserEntity user = getUserEntity(userId);
+
+            verifySeller(product, user);
+
+            checkDuplicateBid(userId, productId);
+
+            PlaceBidResponse placeBidResponse = placeBid(userId, productId, price);
+
+            product.updateHasBuyer();
+
+            sendSellerBidNotification(productId);
+
+            return placeBidResponse;
+        } finally {
+            try {
+                redisBidLockService.decrementBid(bidLockKey);
+            } catch (Exception e) {
+                log.error("입찰 락을 해제하는데 실패했습니다.", e);
+            }
         }
-        return placeBidResponse;
     }
 
+    private static void verifySeller(ProductEntity product, UserEntity user) {
+        if (product.getUser().equals(user)) {
+            throw new DomainException(SELLER_CANNOT_CREATE_BID);
+        }
+    }
+
+    private UserEntity getUserEntity(Long userId) {
+        UserEntity user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new DomainException(USER_NOT_FOUND));
+        return user;
+    }
+
+    private ProductEntity getProductEntity(Long productId) {
+        ProductEntity product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new DomainException(PRODUCT_NOT_FOUND));
+        return product;
+    }
 
     private PlaceBidResponse placeBid(Long userId, Long productId, int price) {
 
-        ProductEntity productEntity = productRepository.findById(productId)
-                .orElseThrow(() -> new WebException(PRODUCT_NOT_FOUND));
+        ProductEntity productEntity = getProductEntity(productId);
 
-        UserEntity userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new WebException(AuctionException.BID_USER_NOT_FOUND));
+        UserEntity userEntity = getUserEntity(userId);
 
         if (productEntity.getMinPrice() > price) {
             throw new WebException(AuctionException.AUCTION_MIN_PRICE_ERROR);
@@ -95,4 +139,11 @@ public class PlaceBidUseCase {
         }
     }
 
+    private void sendSellerBidNotification(Long productId) {
+        try {
+            fcmService.sendSellerBidMessage(productId);
+        } catch (Exception e) {
+            log.error("판매자에게 FCM 알림을 보내지 못했습니다.", e);
+        }
+    }
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/UpdateBidPriceUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/UpdateBidPriceUseCase.java
@@ -1,6 +1,7 @@
 package org.j1p5.api.auction.service.usecase;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.j1p5.api.auction.dto.response.UpdateBidPriceResponse;
 import org.j1p5.api.auction.exception.AuctionException;
 import org.j1p5.api.auction.service.AuctionService;
@@ -11,9 +12,11 @@ import org.j1p5.domain.auction.entity.AuctionEntity;
 import org.j1p5.domain.auction.repository.AuctionRepository;
 import org.j1p5.domain.product.entity.ProductEntity;
 import org.j1p5.domain.product.repository.ProductRepository;
+import org.j1p5.domain.redis.RedisIdempotencyService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UpdateBidPriceUseCase {
@@ -22,10 +25,13 @@ public class UpdateBidPriceUseCase {
     private final AuctionRepository auctionRepository;
     private final FcmService fcmService;
     private final ProductRepository productRepository;
+    private final RedisIdempotencyService redisIdempotencyService;
+
+    private static final long REQUEST_ID_TTL = 30;
 
     /**
-     * 입찰 수정. 본인 입찰만 수정 가능, 조기마감 여부에 따라 수정 범위 제한
-     * 입찰 수정 알림 전송
+     * 입찰 수정. 본인 입찰만 수정 가능, 조기마감 여부에 따라 수정 범위 제한 입찰 수정 알림 전송
+     *
      * @author yechan
      * @param productId
      * @param userId
@@ -36,6 +42,18 @@ public class UpdateBidPriceUseCase {
     @Transactional
     public UpdateBidPriceResponse execute(Long productId, Long userId, Long auctionId, int price) {
 
+        // 멱등성 확인
+        String requestId = "updateBid:" + auctionId + ":user:" + userId;
+        try {
+            if (!redisIdempotencyService.saveRequestId(requestId, REQUEST_ID_TTL)) {
+                throw new WebException(AuctionException.DUPLICATE_BID_UPDATE_REQUEST);
+            }
+        } catch (WebException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("입찰 수정 멱등성 검사에서 에러발생 check 요청: {}", requestId, e);
+        }
+
         auctionService.verifyUserBidOwnership(userId, auctionId);
 
         boolean earlyClosure = auctionService.isEarlyClosure(productId);
@@ -43,9 +61,9 @@ public class UpdateBidPriceUseCase {
         AuctionEntity auctionEntity;
 
         if (earlyClosure) {
-            auctionEntity = updateBidPriceForEarlyClosure(auctionId,price);
-        }else{
-            auctionEntity = updateBidPriceWithMinimumLimit(auctionId,productId,price);
+            auctionEntity = updateBidPriceForEarlyClosure(auctionId, price);
+        } else {
+            auctionEntity = updateBidPriceWithMinimumLimit(auctionId, productId, price);
         }
 
         fcmService.sendSellerBidUpdateMessage(productId);
@@ -83,5 +101,4 @@ public class UpdateBidPriceUseCase {
         auctionRepository.save(auctionEntity);
         return auctionEntity;
     }
-
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/UpdateBidPriceUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/auction/service/usecase/UpdateBidPriceUseCase.java
@@ -2,9 +2,15 @@ package org.j1p5.api.auction.service.usecase;
 
 import lombok.RequiredArgsConstructor;
 import org.j1p5.api.auction.dto.response.UpdateBidPriceResponse;
+import org.j1p5.api.auction.exception.AuctionException;
 import org.j1p5.api.auction.service.AuctionService;
 import org.j1p5.api.fcm.FcmService;
+import org.j1p5.api.global.excpetion.WebException;
+import org.j1p5.api.product.exception.ProductException;
 import org.j1p5.domain.auction.entity.AuctionEntity;
+import org.j1p5.domain.auction.repository.AuctionRepository;
+import org.j1p5.domain.product.entity.ProductEntity;
+import org.j1p5.domain.product.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,7 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateBidPriceUseCase {
 
     private final AuctionService auctionService;
+    private final AuctionRepository auctionRepository;
     private final FcmService fcmService;
+    private final ProductRepository productRepository;
 
     /**
      * 입찰 수정. 본인 입찰만 수정 가능, 조기마감 여부에 따라 수정 범위 제한
@@ -35,13 +43,45 @@ public class UpdateBidPriceUseCase {
         AuctionEntity auctionEntity;
 
         if (earlyClosure) {
-            auctionEntity = auctionService.updateBidPriceForEarlyClosure(auctionId,price);
+            auctionEntity = updateBidPriceForEarlyClosure(auctionId,price);
         }else{
-            auctionEntity = auctionService.updateBidPriceWithMinimumLimit(auctionId,productId,price);
+            auctionEntity = updateBidPriceWithMinimumLimit(auctionId,productId,price);
         }
 
         fcmService.sendSellerBidUpdateMessage(productId);
 
         return UpdateBidPriceResponse.fromEntity(auctionEntity);
     }
+
+    // 조기마감 상태일때의 수정
+    private AuctionEntity updateBidPriceForEarlyClosure(Long auctionId, int price) {
+        AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new WebException(AuctionException.BID_NOT_FOUND));
+
+        if (auctionEntity.getPrice() >= price) {
+            throw new WebException(AuctionException.BID_AMOUNT_TOO_LOW);
+        }
+
+        auctionEntity.updatePrice(price);
+        auctionRepository.save(auctionEntity);
+        return auctionEntity;
+    }
+
+    // 조기마감 상태가 아닐때의 수정
+    public AuctionEntity updateBidPriceWithMinimumLimit(Long auctionId, Long productId, int price) {
+        ProductEntity productEntity = productRepository.findById(productId)
+                .orElseThrow(() -> new WebException(ProductException.PRODUCT_NOT_FOUND));
+
+        if (productEntity.getMinPrice() > price) {
+            throw new WebException(AuctionException.AUCTION_MIN_PRICE_ERROR);
+        }
+
+        AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new WebException(AuctionException.BID_NOT_FOUND));
+
+        auctionEntity.updatePrice(price);
+        auctionRepository.save(auctionEntity);
+        return auctionEntity;
+    }
+
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/event/WebSocketEventListener.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/event/WebSocketEventListener.java
@@ -1,27 +1,24 @@
 package org.j1p5.api.chat.event;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.j1p5.domain.redis.RedisService;
+import org.j1p5.domain.redis.RedisChatService;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
-import java.util.List;
-
 /**
- * @author
- *
- * WebSocket 이벤트 처리를 이용하여 채팅방 입장,퇴장 처리
+ * @author WebSocket 이벤트 처리를 이용하여 채팅방 입장,퇴장 처리
  */
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class WebSocketEventListener {
 
-    private final RedisService redisService;
+    private final RedisChatService redisChatService;
 
     /**
      * 채팅방 접속 시 Redis에 유저-룸 매핑 정보 추가
@@ -40,7 +37,7 @@ public class WebSocketEventListener {
 
         headerAccessor.getSessionAttributes().put("userId", userId);
 
-        redisService.saveUserRoomMapping(userId, roomId);
+        redisChatService.saveUserRoomMapping(userId, roomId);
         log.info("사용자 {}가 채팅방 {}에 입장했습니다. Redis에 기록했습니다.", userId, roomId);
     }
 
@@ -55,36 +52,35 @@ public class WebSocketEventListener {
 
         String userId = (String) headerAccessor.getSessionAttributes().get("userId");
 
-        redisService.removeUserRoomMapping(userId);
+        redisChatService.removeUserRoomMapping(userId);
         log.info("사용자 {}의 채팅방 정보가 Redis에서 삭제되었습니다.", userId);
     }
 
+    private String getUserId(StompHeaderAccessor headerAccessor) {
+        List<String> userIdHeaders = headerAccessor.getNativeHeader("userId");
 
-private String getUserId(StompHeaderAccessor headerAccessor) {
-    List<String> userIdHeaders = headerAccessor.getNativeHeader("userId");
+        if (userIdHeaders == null || userIdHeaders.isEmpty()) {
+            throw new NullPointerException("WebSocket 요청에서 userId 헤더를 찾을 수 없습니다.");
+        }
 
-    if (userIdHeaders == null || userIdHeaders.isEmpty()) {
-        throw new NullPointerException("WebSocket 요청에서 userId 헤더를 찾을 수 없습니다.");
+        return userIdHeaders.get(0);
     }
-
-    return userIdHeaders.get(0);
-}
-
 
     private String getRoomId(StompHeaderAccessor headerAccessor) {
         String destination = headerAccessor.getDestination();
         if (destination == null || !destination.startsWith("/sub/chatroom/")) {
             log.error("잘못된 요청입니다. destination: {}", destination);
-            throw new IllegalArgumentException("WebSocket 요청에서 유효하지 않은 roomId를 받았습니다: " + destination);
+            throw new IllegalArgumentException(
+                    "WebSocket 요청에서 유효하지 않은 roomId를 받았습니다: " + destination);
         }
 
         String roomId = destination.split("/sub/chatroom/")[1];
         if (roomId == null || roomId.isEmpty()) {
             log.error("roomId가 비어 있습니다. destination: {}", destination);
-            throw new IllegalArgumentException("WebSocket 요청에서 유효하지 않은 roomId를 받았습니다: " + destination);
+            throw new IllegalArgumentException(
+                    "WebSocket 요청에서 유효하지 않은 roomId를 받았습니다: " + destination);
         }
 
         return roomId;
     }
 }
-

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/SendChatMessageUseCase.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/chat/service/usecase/SendChatMessageUseCase.java
@@ -1,5 +1,8 @@
 package org.j1p5.api.chat.service.usecase;
 
+import static org.j1p5.api.chat.exception.ChatException.CHAT_RECEIVER_FIND_ERROR;
+import static org.j1p5.api.chat.exception.ChatException.CHAT_SAVE_ERROR;
+
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.j1p5.api.chat.dto.response.ChatMessageResponse;
@@ -12,17 +15,12 @@ import org.j1p5.domain.chat.entity.ChatMessageEntity;
 import org.j1p5.domain.chat.repository.ChatMessageRepository;
 import org.j1p5.domain.chat.repository.ChatRoomRepository;
 import org.j1p5.domain.chat.vo.MessageInfo;
-import org.j1p5.domain.redis.RedisService;
+import org.j1p5.domain.redis.RedisChatService;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
-import static org.j1p5.api.chat.exception.ChatException.CHAT_RECEIVER_FIND_ERROR;
-import static org.j1p5.api.chat.exception.ChatException.CHAT_SAVE_ERROR;
-
-
 /**
- * @author yechan
- * 메시지를 보냈을때 메시지 저장과 채팅방 상태 업데이트
+ * @author yechan 메시지를 보냈을때 메시지 저장과 채팅방 상태 업데이트
  */
 @Service
 @RequiredArgsConstructor
@@ -30,21 +28,19 @@ public class SendChatMessageUseCase {
 
     private final ChatRoomService chatRoomService;
     private final FcmService fcmService;
-    private final RedisService redisService;
+    private final RedisChatService redisChatService;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-
     // 메시지 보내기
-    //@Transactional 추후 적용
+    // @Transactional 추후 적용
     public ChatMessageResponse execute(MessageInfo messageInfo) {
 
         Long userId = messageInfo.getUserId();
         Long receiverId = messageInfo.getReceiverId();
         String roomId = messageInfo.getRoomId();
         String content = messageInfo.getContent();
-
 
         ObjectId roomObjectId = chatRoomService.validateRoomId(roomId);
 
@@ -54,19 +50,22 @@ public class SendChatMessageUseCase {
 
         boolean receiverInChatRoom = isReceiverInChatRoom(roomObjectId, receiverId.toString());
 
-        chatRoomRepository.updateChatRoomInfo(new UpdateChatRoomCommand(roomObjectId, content, receiverId,
-                        receiverInChatRoom, chatMessageEntity.getCreatedAt())
-                );
+        chatRoomRepository.updateChatRoomInfo(
+                new UpdateChatRoomCommand(
+                        roomObjectId,
+                        content,
+                        receiverId,
+                        receiverInChatRoom,
+                        chatMessageEntity.getCreatedAt()));
 
         sendWebSocketMessage(chatMessageEntity);
 
         if (!receiverInChatRoom)
-            fcmService.sendFcmChatMessage(roomId, receiverId, userId, chatMessageEntity.getContent());
+            fcmService.sendFcmChatMessage(
+                    roomId, receiverId, userId, chatMessageEntity.getContent());
 
         return ChatMessageResponse.fromEntity(chatMessageEntity);
     }
-
-
 
     private ChatMessageEntity saveMessage(ObjectId roomId, Long senderId, String content) {
 
@@ -79,11 +78,10 @@ public class SendChatMessageUseCase {
         }
     }
 
-
     private boolean isReceiverInChatRoom(ObjectId roomId, String receiverId) {
 
         try {
-            String userCurrentRoom = redisService.getUserCurrentRoom(receiverId);
+            String userCurrentRoom = redisChatService.getUserCurrentRoom(receiverId);
 
             return roomId.toString().equals(userCurrentRoom);
         } catch (Exception e) {
@@ -91,15 +89,11 @@ public class SendChatMessageUseCase {
         }
     }
 
-
     private void sendWebSocketMessage(ChatMessageEntity chatMessageEntity) {
-        ChatSocketMessageResponse response = ChatSocketMessageResponse.fromEntity(chatMessageEntity);
+        ChatSocketMessageResponse response =
+                ChatSocketMessageResponse.fromEntity(chatMessageEntity);
 
-        simpMessagingTemplate.convertAndSend("/sub/chatroom/" +
-                chatMessageEntity.getRoomId().toString(), response);
-
+        simpMessagingTemplate.convertAndSend(
+                "/sub/chatroom/" + chatMessageEntity.getRoomId().toString(), response);
     }
-
-
-
 }

--- a/meerket/meerket-application/src/main/java/org/j1p5/api/product/exception/ProductException.java
+++ b/meerket/meerket-application/src/main/java/org/j1p5/api/product/exception/ProductException.java
@@ -4,16 +4,18 @@ import org.j1p5.common.exception.BaseErrorCode;
 import org.j1p5.common.exception.ErrorResponse;
 
 public enum ProductException implements BaseErrorCode {
-
     REGION_AUTH_NOT_FOUND(404, "REGION404", "사용자의 동네 인증 정보가 없습니다."),
     PRODUCT_NOT_FOUND(404, "PRODUCT404", "상품 조회에 실패하였습니다."),
     PRODUCT_NOT_AUTHORIZED(403, "PRODUCT403", "상품 수정 권한이 없습니다."),
     PRODUCT_HAS_BUYER(405, "PRODUCT400", "입찰자가 있는 상품은 수정할 수 없습니다."),
-    PRODUCT_HAS_NO_BUYER(400,"PRODUCT400","입찰자가 없어서 조기마감을 할 수 없습니다."),
+    PRODUCT_HAS_NO_BUYER(400, "PRODUCT400", "입찰자가 없어서 조기마감을 할 수 없습니다."),
     PRODUCT_IS_DELETED(410, "PRODUCT410", "삭제된 게시물입니다."),
-    INVALID_PRODUCT_CATEGORY(400, "PRODUCT400","존재하지 않는 카테고리입니다."),
-    INVALID_PRODUCT_KEYWORD(400, "PRODUCT401","올바르지 않은 검색내용입니다."),
-    INVALID_PRODUCT_EARLY_CLOSED(400,"PRODUCT402","이미 마감시간이 2시간 이하이므로 조기마감할 수 없습니다."),
+    INVALID_PRODUCT_CATEGORY(400, "PRODUCT400", "존재하지 않는 카테고리입니다."),
+    INVALID_PRODUCT_KEYWORD(400, "PRODUCT401", "올바르지 않은 검색내용입니다."),
+    INVALID_PRODUCT_EARLY_CLOSED(400, "PRODUCT402", "이미 마감시간이 2시간 이하이므로 조기마감할 수 없습니다."),
+    DUPLICATED_PRODUCT_UPDATE_REQUEST(400, "PRODUCT400", "중복된 상품 수정 요청입니다."),
+    BID_IN_PROGRESS_PRODUCT_UPDATE_NOT_ALLOWED(403, "PRODUCT403", "진행 중인 입찰이 있어 상품을 수정할 수 없습니다."),
+    PRODUCT_UPDATE_LOCKED(409, "PRODUCT409", "현재 상품 수정이 진행 중입니다."),
     ;
     private final int status;
     private final String errorCode;

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisBidLockService.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisBidLockService.java
@@ -1,0 +1,32 @@
+package org.j1p5.domain.redis;
+
+/**
+ * @author yechan
+ */
+public interface RedisBidLockService {
+
+    /**
+     * 입찰 시작: 키 증가 또는 생성
+     *
+     * @param key Redis 키
+     * @param ttl 키 만료 시간(초)
+     * @return 현재 키의 값
+     */
+    long incrementBid(String key, long ttl);
+
+    /**
+     * 입찰 종료: 키 감소 또는 삭제
+     *
+     * @param key Redis 키
+     * @return 현재 키의 값
+     */
+    long decrementBid(String key);
+
+    /**
+     * 현재 입찰이 진행되고 있는지를 확인
+     *
+     * @param key Redis 키
+     * @return 현재 키의 값 (없으면 0 반환)
+     */
+    long getBidCount(String key);
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisChatService.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisChatService.java
@@ -1,6 +1,6 @@
 package org.j1p5.domain.redis;
 
-public interface RedisService {
+public interface RedisChatService {
 
     /**
      * 특정 사용자와 채팅방을 매핑하여 저장합니다.
@@ -24,5 +24,4 @@ public interface RedisService {
      * @param userId
      */
     void removeUserRoomMapping(String userId);
-
 }

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisIdempotencyService.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisIdempotencyService.java
@@ -1,0 +1,16 @@
+package org.j1p5.domain.redis;
+
+/**
+ * @author yechan
+ */
+public interface RedisIdempotencyService {
+
+    /**
+     * 요청 ID 저장(멱등성 보장)
+     *
+     * @param requestId 요청 고유 ID
+     * @param ttl 키 만료 시간(초)
+     * @return true: 성공적으로 저장됨, false: 이미 처리된 요청
+     */
+    boolean saveRequestId(String requestId, long ttl);
+}

--- a/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisProductEditLockService.java
+++ b/meerket/meerket-domain/src/main/java/org/j1p5/domain/redis/RedisProductEditLockService.java
@@ -1,0 +1,28 @@
+package org.j1p5.domain.redis;
+
+public interface RedisProductEditLockService {
+
+    /**
+     * 상품 수정할때의 Lock
+     *
+     * @param key
+     * @param ttl
+     * @return true: lock 성공, false: 이미 lock 되어있음
+     */
+    boolean setEditLock(String key, long ttl);
+
+    /**
+     * 상품이 수정중인지 확인
+     *
+     * @param key
+     * @return true: 상품이 수정중인 상태, false: 상품이 수정중 아닌상태
+     */
+    boolean isEditLocked(String key);
+
+    /**
+     * 상품의 수정이 완료되고 나서 Lock 해제
+     *
+     * @param key
+     */
+    void releaseEditLock(String key);
+}

--- a/meerket/meerket-infrastructure/build.gradle
+++ b/meerket/meerket-infrastructure/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     // redis 의존성
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.39.0'
+
 
     // firebase 의존성
     implementation 'com.google.firebase:firebase-admin:9.4.1'

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/config/RedisConfig.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package org.j1p5.infrastructure.redis.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,13 +26,26 @@ public class RedisConfig {
     }
 
     @Bean(name = "redisTemplate")
-    public RedisTemplate<String, String> queueRedisTemplate() {
+    public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.afterPropertiesSet();
 
         return redisTemplate;
+    }
+
+    @Bean
+    public RedissonClient redisClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port)
+                .setRetryAttempts(3)
+                .setRetryInterval(1500)
+                .setTimeout(3000)
+                .setConnectTimeout(10000);
+        return Redisson.create(config);
     }
 }

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/config/RedisConfig.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/config/RedisConfig.java
@@ -14,6 +14,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
     @Value("${spring.data.redis.host}")
     private String host;
 
@@ -41,7 +43,7 @@ public class RedisConfig {
     public RedissonClient redisClient() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://" + host + ":" + port)
+                .setAddress(REDISSON_HOST_PREFIX + host + ":" + port)
                 .setRetryAttempts(3)
                 .setRetryInterval(1500)
                 .setTimeout(3000)

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisBidLockServiceImpl.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisBidLockServiceImpl.java
@@ -2,6 +2,7 @@ package org.j1p5.infrastructure.redis.service;
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.j1p5.domain.redis.RedisBidLockService;
 import org.redisson.api.RAtomicLong;
 import org.redisson.api.RedissonClient;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 /**
  * @author yechan
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisBidLockServiceImpl implements RedisBidLockService {
@@ -27,6 +29,9 @@ public class RedisBidLockServiceImpl implements RedisBidLockService {
     public long incrementBid(String key, long ttl) {
         RAtomicLong atomicLong = redissonClient.getAtomicLong(key);
         long currentValue = atomicLong.incrementAndGet();
+
+        log.info("현재 입찰 락 증가  key = {}", key);
+        log.info("현재 입찰 락 증가  count = {}", currentValue);
 
         if (currentValue == 1) {
             atomicLong.expire(Duration.ofSeconds(ttl));
@@ -46,6 +51,9 @@ public class RedisBidLockServiceImpl implements RedisBidLockService {
         RAtomicLong atomicLong = redissonClient.getAtomicLong(key);
         long currentValue = atomicLong.decrementAndGet();
 
+        log.info("현재 입찰 락 감소  key = {}", key);
+        log.info("현재 입찰 락 감소  count = {}", currentValue);
+
         if (currentValue <= 0) {
             atomicLong.delete();
         }
@@ -62,6 +70,9 @@ public class RedisBidLockServiceImpl implements RedisBidLockService {
     @Override
     public long getBidCount(String key) {
         RAtomicLong atomicLong = redissonClient.getAtomicLong(key);
+
+        log.info("현재 입찰 중 개수 = {}", atomicLong);
+
         return atomicLong.get();
     }
 }

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisBidLockServiceImpl.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisBidLockServiceImpl.java
@@ -1,0 +1,67 @@
+package org.j1p5.infrastructure.redis.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.j1p5.domain.redis.RedisBidLockService;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author yechan
+ */
+@Service
+@RequiredArgsConstructor
+public class RedisBidLockServiceImpl implements RedisBidLockService {
+
+    private final RedissonClient redissonClient;
+
+    /**
+     * 입찰 시작: 키 증가 또는 생성
+     *
+     * @param key Redis 키
+     * @param ttl 키 만료 시간(초)
+     * @return 현재 키의 값
+     */
+    @Override
+    public long incrementBid(String key, long ttl) {
+        RAtomicLong atomicLong = redissonClient.getAtomicLong(key);
+        long currentValue = atomicLong.incrementAndGet();
+
+        if (currentValue == 1) {
+            atomicLong.expire(Duration.ofSeconds(ttl));
+        }
+
+        return currentValue;
+    }
+
+    /**
+     * 입찰 종료: 키 감소 또는 삭제
+     *
+     * @param key Redis 키
+     * @return 현재 키의 값
+     */
+    @Override
+    public long decrementBid(String key) {
+        RAtomicLong atomicLong = redissonClient.getAtomicLong(key);
+        long currentValue = atomicLong.decrementAndGet();
+
+        if (currentValue <= 0) {
+            atomicLong.delete();
+        }
+
+        return currentValue;
+    }
+
+    /**
+     * 현재 입찰이 진행되고 있는지를 확인
+     *
+     * @param key Redis 키
+     * @return 현재 키의 값 (없으면 0 반환)
+     */
+    @Override
+    public long getBidCount(String key) {
+        RAtomicLong atomicLong = redissonClient.getAtomicLong(key);
+        return atomicLong.get();
+    }
+}

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisChatChatServiceImpl.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisChatChatServiceImpl.java
@@ -1,7 +1,7 @@
-package org.j1p5.infrastructure.redis;
+package org.j1p5.infrastructure.redis.service;
 
 import lombok.RequiredArgsConstructor;
-import org.j1p5.domain.redis.RedisService;
+import org.j1p5.domain.redis.RedisChatService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
-public class RedisServiceImpl implements RedisService {
+public class RedisChatChatServiceImpl implements RedisChatService {
 
     @Qualifier("redisTemplate")
     private final RedisTemplate<String, String> redisTemplate;

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisIdempotencyServiceImpl.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisIdempotencyServiceImpl.java
@@ -1,0 +1,36 @@
+package org.j1p5.infrastructure.redis.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.j1p5.domain.redis.RedisIdempotencyService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author yechan
+ */
+@Service
+@RequiredArgsConstructor
+public class RedisIdempotencyServiceImpl implements RedisIdempotencyService {
+
+    @Qualifier("redisTemplate")
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 요청 ID 저장(멱등성 보장)
+     *
+     * @param requestId 요청 고유 ID
+     * @param ttl 키 만료 시간(초)
+     * @return true: 성공적으로 저장됨, false: 이미 처리된 요청
+     */
+    @Override
+    public boolean saveRequestId(String requestId, long ttl) {
+        Boolean success =
+                redisTemplate
+                        .opsForValue()
+                        .setIfAbsent(requestId, "PROCESSED", ttl, TimeUnit.SECONDS);
+
+        return success != null && success;
+    }
+}

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisIdempotencyServiceImpl.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisIdempotencyServiceImpl.java
@@ -2,6 +2,7 @@ package org.j1p5.infrastructure.redis.service;
 
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.j1p5.domain.redis.RedisIdempotencyService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 /**
  * @author yechan
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisIdempotencyServiceImpl implements RedisIdempotencyService {
@@ -30,6 +32,8 @@ public class RedisIdempotencyServiceImpl implements RedisIdempotencyService {
                 redisTemplate
                         .opsForValue()
                         .setIfAbsent(requestId, "PROCESSED", ttl, TimeUnit.SECONDS);
+
+        log.info("멱등성 여부 확인 결과 requestId = {}, 결과 =  {}", requestId, success);
 
         return success != null && success;
     }

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisProductEditLockServiceImpl.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisProductEditLockServiceImpl.java
@@ -2,6 +2,7 @@ package org.j1p5.infrastructure.redis.service;
 
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.j1p5.domain.redis.RedisProductEditLockService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 /**
  * @author yechan
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisProductEditLockServiceImpl implements RedisProductEditLockService {
@@ -26,6 +28,7 @@ public class RedisProductEditLockServiceImpl implements RedisProductEditLockServ
      */
     @Override
     public boolean setEditLock(String key, long ttl) {
+        log.info("상품 수정 락 설정");
         return Boolean.TRUE.equals(
                 redisTemplate.opsForValue().setIfAbsent(key, "LOCKED", ttl, TimeUnit.SECONDS));
     }
@@ -38,6 +41,7 @@ public class RedisProductEditLockServiceImpl implements RedisProductEditLockServ
      */
     @Override
     public boolean isEditLocked(String key) {
+        log.info("상품 수정 락 확인");
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
@@ -48,6 +52,7 @@ public class RedisProductEditLockServiceImpl implements RedisProductEditLockServ
      */
     @Override
     public void releaseEditLock(String key) {
+        log.info("상품 수정 락 해제");
         redisTemplate.delete(key);
     }
 }

--- a/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisProductEditLockServiceImpl.java
+++ b/meerket/meerket-infrastructure/src/main/java/org/j1p5/infrastructure/redis/service/RedisProductEditLockServiceImpl.java
@@ -1,0 +1,53 @@
+package org.j1p5.infrastructure.redis.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.j1p5.domain.redis.RedisProductEditLockService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author yechan
+ */
+@Service
+@RequiredArgsConstructor
+public class RedisProductEditLockServiceImpl implements RedisProductEditLockService {
+
+    @Qualifier("redisTemplate")
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 상품 수정할때의 Lock
+     *
+     * @param key
+     * @param ttl
+     * @return true: lock 성공, false: 이미 lock 되어있음
+     */
+    @Override
+    public boolean setEditLock(String key, long ttl) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForValue().setIfAbsent(key, "LOCKED", ttl, TimeUnit.SECONDS));
+    }
+
+    /**
+     * 상품이 수정중인지 확인
+     *
+     * @param key
+     * @return true: 상품이 수정중인 상태, false: 상품이 수정중 아닌상태
+     */
+    @Override
+    public boolean isEditLocked(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    /**
+     * 상품의 수정이 완료되고 나서 Lock 해제
+     *
+     * @param key
+     */
+    @Override
+    public void releaseEditLock(String key) {
+        redisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->
<br/> #155 

## 💭 작업 내용
<!-- 작업한 내용을 간단히 설명해주세요 -->
<br/> 
- 기존 Auction 도메인 코드를 리팩토링 했습니다. </br>
- 입찰을 할때, 입찰을 수정할때, 상품을 수정할때 멱등성(따닥 방지)과 Redisson을 활용하여 동시성 제어를 구현했습니다.


## 🤔 참고 사항
<!-- 참고 사항을 설명해주세요 -->
<br/> 
- 입찰시 거리기반으로 입찰이 진행되도록 하는것은 추후 구현예정입니다! 현재는 100km 고정이지만 추후 사용자에게 거리를 설정할 수 있게 한다면 구현방식을 고민해볼 필요가 있을 것 같습니다!


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br/> 
<h4>현재 구현된 멱등성과 동시성 제어는 아래와 같습니다 살펴보시고 코멘트 남겨주세요!</h4> <br/>
- 멱등성이 보장되지않는 POST, PATCH 매핑에 대해서 멱등성을 구현하였습니다. <br/><br/>
- 현재 멱등성 인증에 사용되는 TTL은 30초인데 실제로 네트워크가 지연되어서 문제가 발생하는경우를 감안하면 좀 더 늘려야 되겠지만 우선은 사용자가 많지않고 네트워크 지연이 30초이상 걸리지 않을것이라는 가정으로 30초로 해두었습니다. 또한 TTL을 너무 길게 하면 실제로 네트워크나 서버의 문제로 입찰이 실패되었을때 해당 TTL만큼 재입찰을 할 수 없기때문에 입찰시간이 중요한 만큼 TTL을 비교적 짧게 세팅해두었습니다.<br/><br/>
- 입찰가격 수정과 상품 정보 수정의 경우 멱등성이 무조건적으로 보장될 필요는 없다고 보지만 입찰가격수정의 경우 0.1초차이로도 낙찰자가 바뀔 수 있기때문에 멱등성을 보장하였고, 상품가격수정도 코드의 일관성을 위해 멱등성을 추가하였습니다.<br/><br/>

<h4>현재 고려된 동시성은 아래와 같습니다.</h4>
- 입찰이 이루어지는 동안 상품 수정이 발생하는 경우 방지(최소 입찰가가 10000원이었을때 구매자가 10000원으로 입찰을 하는동안 판매자가 최소입찰가를 15000원으로 올려 최소입찰가보다 더 낮은 입찰금액이 발생하는경우 방지) </br></br>
- 상품 정보를 수정하는 동안 입찰이 이루어지는 경우 방지(최소 입찰가가 10000원이었을때 판매자가 최소입찰가를 15000원으로 올리는 동안 구매자가 10000원으로 입찰하는 경우 방지)
